### PR TITLE
Implements templated 'destination' (topic, subject, channel)

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -224,3 +224,5 @@ Available key types are:
 If unset, an empty key is assigned during translation from NATS to Kafka. If the regex types are used and they don't match, an empty key is used.
 
 For nats streaming connections channel is treated as the subject and durable name is treated as the reply to, so that reply key type will use the durable name as the key.
+
+Every destination, may it be channel, subject or topic may be set using a go template that gets the message as data. e.g `topic: "{{ .Subject }}"`. Two template functions are available: replace (`"{{ .Subject | replace \"event\" \"message\" }}`) and substring (`"{{ .Subject | substring 0 5 }}"`)

--- a/server/core/kafka2nats.go
+++ b/server/core/kafka2nats.go
@@ -33,7 +33,7 @@ type Kafka2NATSConnector struct {
 // NewKafka2NATSConnector create a new Kafka to NATS connector
 func NewKafka2NATSConnector(bridge *NATSKafkaBridge, config conf.ConnectorConfig) Connector {
 	connector := &Kafka2NATSConnector{}
-	connector.init(bridge, config, fmt.Sprintf("Kafka:%s to NATS:%s", config.Topic, config.Subject))
+	connector.init(bridge, config, config.Subject, fmt.Sprintf("Kafka:%s to NATS:%s", config.Topic, config.Subject))
 	return connector
 }
 
@@ -67,6 +67,7 @@ func (conn *Kafka2NATSConnector) Start() error {
 func (conn *Kafka2NATSConnector) Shutdown() error {
 	conn.Lock()
 	defer conn.Unlock()
+	conn.closeWriters()
 	conn.stats.AddDisconnect()
 
 	conn.bridge.Logger().Noticef("shutting down connection %s", conn.String())

--- a/server/core/kafka2stan.go
+++ b/server/core/kafka2stan.go
@@ -33,7 +33,7 @@ type Kafka2StanConnector struct {
 // NewKafka2StanConnector create a new Kafka to STAN connector
 func NewKafka2StanConnector(bridge *NATSKafkaBridge, config conf.ConnectorConfig) Connector {
 	connector := &Kafka2StanConnector{}
-	connector.init(bridge, config, fmt.Sprintf("Kafka:%s to NATS:%s", config.Topic, config.Subject))
+	connector.init(bridge, config, config.Channel, fmt.Sprintf("Kafka:%s to Stan:%s", config.Topic, config.Channel))
 	return connector
 }
 
@@ -67,6 +67,7 @@ func (conn *Kafka2StanConnector) Start() error {
 func (conn *Kafka2StanConnector) Shutdown() error {
 	conn.Lock()
 	defer conn.Unlock()
+	conn.closeWriters()
 	conn.stats.AddDisconnect()
 
 	conn.bridge.Logger().Noticef("shutting down connection %s", conn.String())


### PR DESCRIPTION
Close #10 

Bring golang template and 2 template functions (replace, substring) to help with "destination" (topic, subject, channel) definition.

Some performances related insights:

3K messages on master branch
```
    {
      "name": "NATS:> to Kafka:events",
      "id": "zJapCmG5BUw7lFQgLnKkzV",
      "connected": true,
      "connects": 1,
      "disconnects": 0,
      "bytes_in": 22885,
      "bytes_out": 22885,
      "msg_in": 2999,
      "msg_out": 2999,
      "count": 2999,
      "rma": 4142986.176725575,
      "q50": 3541906.348870057,
      "q75": 3914790.1003134795,
      "q90": 4556933.919117645,
      "q95": 4940597.268041236
    }
```

3K messages using template (but a single `.Subject` value, so a single topic)
```
    {
      "name": "NATS:> to Kafka:event.{{ .Subject }}",
      "id": "VV6N9CynhG8vNtJ8i1Q2rR",
      "connected": true,
      "connects": 1,
      "disconnects": 0,
      "bytes_in": 22885,
      "bytes_out": 22885,
      "msg_in": 2999,
      "msg_out": 2999,
      "count": 2999,
      "rma": 4184608.477492493,
      "q50": 3229506.4765625,
      "q75": 3888502.1231231233,
      "q90": 4574375.737588651,
      "q95": 5018858.678160922
    }
```