### PR TITLE
[FIXED] Several issues

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -12,7 +12,9 @@ The bridge uses a single configuration file passed on the command line or enviro
 * [NATS Streaming](#stan)
 * [Connectors](#connectors)
 
-The configuration file format matches the NATS server and supports file includes of the form:
+The configuration file format matches the NATS server. Details can be found [here](https://docs.nats.io/nats-server/configuration#include-directive).
+
+**IMPORTANT**: Includes *must* use relative paths, and are relative to the main configuration.
 
 ```yaml
 include "./includes/connectors.conf"

--- a/server/core/kafka2nats_test.go
+++ b/server/core/kafka2nats_test.go
@@ -18,10 +18,10 @@ package core
 import (
 	"testing"
 
+	"github.com/nats-io/nats-kafka/server/conf"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nuid"
 	"github.com/stretchr/testify/require"
-	"github.com/nats-io/nats-kafka/server/conf"
 )
 
 func TestSimpleSendOnKafkaReceiveOnNATS(t *testing.T) {

--- a/server/core/kafka2stan_test.go
+++ b/server/core/kafka2stan_test.go
@@ -18,11 +18,26 @@ package core
 import (
 	"testing"
 
+	"github.com/nats-io/nats-kafka/server/conf"
 	"github.com/nats-io/nuid"
 	"github.com/nats-io/stan.go"
 	"github.com/stretchr/testify/require"
-	"github.com/nats-io/nats-kafka/server/conf"
 )
+
+func TestValidateConfiguration(t *testing.T) {
+	topic := nuid.Next()
+
+	// No channel specified
+	connect := []conf.ConnectorConfig{{Type: "KafkaToStan", ID: "kts", Topic: topic}}
+	_, err := StartTestEnvironment(connect)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "STAN channel name not specified")
+
+	connect = []conf.ConnectorConfig{{Type: "STANToKafka", ID: "stk", Topic: topic}}
+	_, err = StartTestEnvironment(connect)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "STAN channel name not specified")
+}
 
 func TestSimpleSendOnKafkaReceiveOnStan(t *testing.T) {
 	channel := "test"

--- a/server/core/nats.go
+++ b/server/core/nats.go
@@ -127,6 +127,9 @@ func (server *NATSKafkaBridge) connectToSTAN() error {
 
 	server.logger.Noticef("connecting to NATS streaming")
 	config := server.config.STAN
+	if config.DiscoverPrefix == "" {
+		config.DiscoverPrefix = stan.DefaultDiscoverPrefix
+	}
 
 	sc, err := stan.Connect(config.ClusterID, config.ClientID,
 		stan.NatsConn(server.nats),

--- a/server/core/nats2kafka_test.go
+++ b/server/core/nats2kafka_test.go
@@ -18,9 +18,9 @@ package core
 import (
 	"testing"
 
+	"github.com/nats-io/nats-kafka/server/conf"
 	"github.com/nats-io/nuid"
 	"github.com/stretchr/testify/require"
-	"github.com/nats-io/nats-kafka/server/conf"
 )
 
 func TestSimpleSendOnNatsReceiveOnKafka(t *testing.T) {

--- a/server/core/server_config_test.go
+++ b/server/core/server_config_test.go
@@ -32,7 +32,7 @@ import (
 func TestStartWithConfigFileFlag(t *testing.T) {
 	topic := nuid.Next()
 
-	tbs, err := StartTestEnvironmentInfrastructure(false,false, []string{topic})
+	tbs, err := StartTestEnvironmentInfrastructure(false, false, []string{topic})
 	require.NoError(t, err)
 	defer tbs.Close()
 
@@ -87,7 +87,7 @@ func TestStartWithConfigFileFlag(t *testing.T) {
 func TestStartWithConfigFileEnv(t *testing.T) {
 	topic := nuid.Next()
 
-	tbs, err := StartTestEnvironmentInfrastructure(false,false, []string{topic})
+	tbs, err := StartTestEnvironmentInfrastructure(false, false, []string{topic})
 	require.NoError(t, err)
 	defer tbs.Close()
 

--- a/server/core/server_test.go
+++ b/server/core/server_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/nats-io/nats-kafka/server/conf"
 	gnatsserver "github.com/nats-io/nats-server/v2/server"
 	gnatsd "github.com/nats-io/nats-server/v2/test"
 	nss "github.com/nats-io/nats-streaming-server/server"
@@ -29,7 +30,6 @@ import (
 	"github.com/nats-io/stan.go"
 	"github.com/segmentio/kafka-go"
 	"github.com/segmentio/kafka-go/sasl/plain"
-	"github.com/nats-io/nats-kafka/server/conf"
 )
 
 const (

--- a/server/core/stan2kafka_test.go
+++ b/server/core/stan2kafka_test.go
@@ -20,9 +20,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/nats-io/nats-kafka/server/conf"
 	"github.com/nats-io/nuid"
 	"github.com/stretchr/testify/require"
-	"github.com/nats-io/nats-kafka/server/conf"
 )
 
 func TestSimpleSendOnStanReceiveOnKafka(t *testing.T) {


### PR DESCRIPTION
- If DiscoverPrefix in NATSStreamingConfig object is not set, use
  default value instead of passing the empty value which causes
  connections to fail.
- Log all publish errors as ERR not notices (INF).
- Absence of channel in a STAN config should cause the bridge
  to fail to start. Without channel specified, publishes to STAN
  produce an invalid publish request.
- Update doc to point to "include" details for configuration parsing
  and add IMPORTANT note that the include is using relative path.

The IDE has fixed some of the imports and fmt with missing spaces,
etc..

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>