### PR TITLE
[FIXED] Reconnect logic

### DIFF
--- a/server/core/connector.go
+++ b/server/core/connector.go
@@ -327,7 +327,7 @@ func (conn *BridgeConnector) subscribeToChannel() (stan.Subscription, error) {
 
 		if err != nil {
 			conn.stats.AddMessageIn(l)
-			conn.bridge.Logger().Noticef("connector publish failure, %s, %s", conn.String(), err.Error())
+			conn.bridge.Logger().Errorf("connector publish failure, %s, %s", conn.String(), err.Error())
 		} else {
 			if traceEnabled {
 				conn.bridge.Logger().Tracef("%s wrote message to kafka with key %s", conn.String(), string(key))

--- a/server/core/kafka2nats_test.go
+++ b/server/core/kafka2nats_test.go
@@ -17,6 +17,7 @@ package core
 
 import (
 	"testing"
+	"time"
 
 	"github.com/nats-io/nats-kafka/server/conf"
 	"github.com/nats-io/nats.go"
@@ -134,6 +135,11 @@ func TestSimpleSendOnKafkaReceiveOnNATSWithGroup(t *testing.T) {
 	tbs, err := StartTestEnvironment(connect)
 	require.NoError(t, err)
 	defer tbs.Close()
+
+	// This test almost always fails if we don't wait a bit here.
+	// It has probably something to do with some initialization in Kafka,
+	// but I am not sure what. This delay is not bullet proof but at least helps.
+	time.Sleep(time.Second)
 
 	done := make(chan string)
 


### PR DESCRIPTION
- When NATS connection is terminally closed (due to MaxReconnects
not being infinite), the bridge is shutdown. The process will now
also exit with a os.Exit(2) to notify docker/system that the exit
was "abnormal".
- On clean shutdown (ctrl+c) the streaming connection should be
closed *before* the NATS connection since with streaming, protocols
are sent to the streaming server and needs the low level NATS
connection.
- The STAN to Kafka connector was not using Errorf() to trace publish
errors to Kafka
- ensureReconnectTimer() was improperly calling itself on error
but continued for NATS/STAN and connectors, which was leading to
the timer be invoked many, many times..

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>