### PR TITLE
Reword paragraph about config file

### DIFF
--- a/docs/buildandrun.md
+++ b/docs/buildandrun.md
@@ -3,8 +3,7 @@
 ## Running the server
 
 The server will compile to an executable named `nats-kafka`. A
-[configuration](config.md) file is required to get any real behavior out of the
-server.
+[configuration](config.md) file is required to start the server.
 
 To specify the [configuration](config.md) file, use the `-c` flag:
 

--- a/server/core/nats2kafka_test.go
+++ b/server/core/nats2kafka_test.go
@@ -24,6 +24,10 @@ import (
 )
 
 func TestSimpleSendOnNatsReceiveOnKafka(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
 	subject := "test"
 	topic := nuid.Next()
 	msg := "hello world"


### PR DESCRIPTION
Even though it sounds like the server might work without the config, that doesn't seem to be the case.

```
$ ./nats-kafka 
2021/01/14 18:46:02.427410 [INF] starting NATS-Kafka Bridge, version 0.0-dev
2021/01/14 18:46:02.427513 [INF] server time is Thu Jan 14 18:46:02 PST 2021
2021/01/14 18:46:02.427520 [INF] connecting to NATS core
2021/01/14 18:46:02.428127 [ERR] error starting bridge, nats: no servers available for connection
2021/01/14 18:46:02.428169 [INF] stopping bridge
2021/01/14 18:46:02.428178 [INF] http monitoring stopped
```

This updates the doc to say that a config file is required.