### PR TITLE
Fix TLS config for SASL

### DIFF
--- a/server/kafka/consumer.go
+++ b/server/kafka/consumer.go
@@ -18,6 +18,7 @@ package kafka
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"time"
 
@@ -61,8 +62,17 @@ func NewConsumer(cc conf.ConnectorConfig, dialTimeout time.Duration) (Consumer, 
 
 	if cc.SASL.User != "" {
 		sc.Net.SASL.Enable = true
+		sc.Net.SASL.Handshake = true
+		sc.Net.SASL.Mechanism = sarama.SASLTypePlaintext
 		sc.Net.SASL.User = cc.SASL.User
 		sc.Net.SASL.Password = cc.SASL.Password
+
+		if cc.SASL.InsecureSkipVerify {
+			sc.Net.TLS.Enable = true
+			sc.Net.TLS.Config = &tls.Config{
+				InsecureSkipVerify: cc.SASL.InsecureSkipVerify,
+			}
+		}
 	} else if tlsC, err := cc.TLS.MakeTLSConfig(); err == nil {
 		sc.Net.TLS.Enable = (tlsC != nil)
 		sc.Net.TLS.Config = tlsC

--- a/server/kafka/manager.go
+++ b/server/kafka/manager.go
@@ -17,6 +17,7 @@
 package kafka
 
 import (
+	"crypto/tls"
 	"time"
 
 	"github.com/Shopify/sarama"
@@ -39,8 +40,17 @@ func NewManager(cc conf.ConnectorConfig, bc conf.NATSKafkaBridgeConfig) (Manager
 
 	if cc.SASL.User != "" {
 		sc.Net.SASL.Enable = true
+		sc.Net.SASL.Handshake = true
+		sc.Net.SASL.Mechanism = sarama.SASLTypePlaintext
 		sc.Net.SASL.User = cc.SASL.User
 		sc.Net.SASL.Password = cc.SASL.Password
+
+		if cc.SASL.InsecureSkipVerify {
+			sc.Net.TLS.Enable = true
+			sc.Net.TLS.Config = &tls.Config{
+				InsecureSkipVerify: cc.SASL.InsecureSkipVerify,
+			}
+		}
 	} else if tlsC, err := cc.TLS.MakeTLSConfig(); err == nil {
 		sc.Net.TLS.Enable = (tlsC != nil)
 		sc.Net.TLS.Config = tlsC

--- a/server/kafka/producer.go
+++ b/server/kafka/producer.go
@@ -17,6 +17,7 @@
 package kafka
 
 import (
+	"crypto/tls"
 	"errors"
 	"time"
 
@@ -50,8 +51,17 @@ func NewProducer(cc conf.ConnectorConfig, bc conf.NATSKafkaBridgeConfig, topic s
 
 	if cc.SASL.User != "" {
 		sc.Net.SASL.Enable = true
+		sc.Net.SASL.Handshake = true
+		sc.Net.SASL.Mechanism = sarama.SASLTypePlaintext
 		sc.Net.SASL.User = cc.SASL.User
 		sc.Net.SASL.Password = cc.SASL.Password
+
+		if cc.SASL.InsecureSkipVerify {
+			sc.Net.TLS.Enable = true
+			sc.Net.TLS.Config = &tls.Config{
+				InsecureSkipVerify: cc.SASL.InsecureSkipVerify,
+			}
+		}
 	} else if tlsC, err := cc.TLS.MakeTLSConfig(); err == nil {
 		sc.Net.TLS.Enable = (tlsC != nil)
 		sc.Net.TLS.Config = tlsC


### PR DESCRIPTION
Currently, we don't honor the InsecureSkipVerify parameter. This causes
connection problems when connecting to Azure.

This change adds TLS config for InsecureSkipVerify when using SASL.

Resolves #26 