### PR TITLE
Support connections with SASL and TLS

### DIFF
--- a/server/core/connector.go
+++ b/server/core/connector.go
@@ -392,6 +392,9 @@ func (conn *BridgeConnector) writer(msg interface{}) kafka.Producer {
 		} else {
 			w = sp
 		}
+		if s, ok := w.(interface{ NetInfo() string }); ok {
+			conn.bridge.Logger().Noticef(s.NetInfo())
+		}
 
 		conn.writers.Store(h, w)
 	}

--- a/server/core/kafka2nats.go
+++ b/server/core/kafka2nats.go
@@ -55,6 +55,9 @@ func (conn *Kafka2NATSConnector) Start() error {
 		return err
 	}
 	conn.reader = r
+	if s, ok := conn.reader.(interface{ NetInfo() string }); ok {
+		conn.bridge.Logger().Noticef(s.NetInfo())
+	}
 
 	cb, err := conn.setUpListener(conn.reader, conn.natsMessageHandler)
 	if err != nil {

--- a/server/core/kafka2stan.go
+++ b/server/core/kafka2stan.go
@@ -55,6 +55,9 @@ func (conn *Kafka2StanConnector) Start() error {
 	if err != nil {
 		return fmt.Errorf("failed to create consumer: %w", err)
 	}
+	if s, ok := conn.reader.(interface{ NetInfo() string }); ok {
+		conn.bridge.Logger().Noticef(s.NetInfo())
+	}
 
 	cb, err := conn.setUpListener(conn.reader, conn.stanMessageHandler)
 	if err != nil {

--- a/server/kafka/consumer.go
+++ b/server/kafka/consumer.go
@@ -66,15 +66,14 @@ func NewConsumer(cc conf.ConnectorConfig, dialTimeout time.Duration) (Consumer, 
 		sc.Net.SASL.Mechanism = sarama.SASLTypePlaintext
 		sc.Net.SASL.User = cc.SASL.User
 		sc.Net.SASL.Password = cc.SASL.Password
-
-		if cc.SASL.InsecureSkipVerify {
-			sc.Net.TLS.Enable = true
-			sc.Net.TLS.Config = &tls.Config{
-				InsecureSkipVerify: cc.SASL.InsecureSkipVerify,
-			}
+	}
+	if sc.Net.SASL.Enable && cc.SASL.InsecureSkipVerify {
+		sc.Net.TLS.Enable = true
+		sc.Net.TLS.Config = &tls.Config{
+			InsecureSkipVerify: cc.SASL.InsecureSkipVerify,
 		}
-	} else if tlsC, err := cc.TLS.MakeTLSConfig(); err == nil {
-		sc.Net.TLS.Enable = (tlsC != nil)
+	} else if tlsC, err := cc.TLS.MakeTLSConfig(); tlsC != nil && err == nil {
+		sc.Net.TLS.Enable = true
 		sc.Net.TLS.Config = tlsC
 	}
 

--- a/server/kafka/manager.go
+++ b/server/kafka/manager.go
@@ -44,15 +44,14 @@ func NewManager(cc conf.ConnectorConfig, bc conf.NATSKafkaBridgeConfig) (Manager
 		sc.Net.SASL.Mechanism = sarama.SASLTypePlaintext
 		sc.Net.SASL.User = cc.SASL.User
 		sc.Net.SASL.Password = cc.SASL.Password
-
-		if cc.SASL.InsecureSkipVerify {
-			sc.Net.TLS.Enable = true
-			sc.Net.TLS.Config = &tls.Config{
-				InsecureSkipVerify: cc.SASL.InsecureSkipVerify,
-			}
+	}
+	if sc.Net.SASL.Enable && cc.SASL.InsecureSkipVerify {
+		sc.Net.TLS.Enable = true
+		sc.Net.TLS.Config = &tls.Config{
+			InsecureSkipVerify: cc.SASL.InsecureSkipVerify,
 		}
-	} else if tlsC, err := cc.TLS.MakeTLSConfig(); err == nil {
-		sc.Net.TLS.Enable = (tlsC != nil)
+	} else if tlsC, err := cc.TLS.MakeTLSConfig(); tlsC != nil && err == nil {
+		sc.Net.TLS.Enable = true
 		sc.Net.TLS.Config = tlsC
 	}
 

--- a/server/kafka/producer.go
+++ b/server/kafka/producer.go
@@ -55,15 +55,14 @@ func NewProducer(cc conf.ConnectorConfig, bc conf.NATSKafkaBridgeConfig, topic s
 		sc.Net.SASL.Mechanism = sarama.SASLTypePlaintext
 		sc.Net.SASL.User = cc.SASL.User
 		sc.Net.SASL.Password = cc.SASL.Password
-
-		if cc.SASL.InsecureSkipVerify {
-			sc.Net.TLS.Enable = true
-			sc.Net.TLS.Config = &tls.Config{
-				InsecureSkipVerify: cc.SASL.InsecureSkipVerify,
-			}
+	}
+	if sc.Net.SASL.Enable && cc.SASL.InsecureSkipVerify {
+		sc.Net.TLS.Enable = true
+		sc.Net.TLS.Config = &tls.Config{
+			InsecureSkipVerify: cc.SASL.InsecureSkipVerify,
 		}
-	} else if tlsC, err := cc.TLS.MakeTLSConfig(); err == nil {
-		sc.Net.TLS.Enable = (tlsC != nil)
+	} else if tlsC, err := cc.TLS.MakeTLSConfig(); tlsC != nil && err == nil {
+		sc.Net.TLS.Enable = true
 		sc.Net.TLS.Config = tlsC
 	}
 


### PR DESCRIPTION
Currently, users can only choose between SASL and TLS insecure skip verify and full TLS. This change allows users to use SASL with full TLS.