### PR TITLE
Add JetStream support

### DIFF
--- a/server/conf/conf.go
+++ b/server/conf/conf.go
@@ -54,10 +54,15 @@ const (
 	KafkaToNATS = "KafkaToNATS"
 	// KafkaToStan specifies a connector from Kafka to NATS streaming
 	KafkaToStan = "KafkaToStan"
+	// KafkaToJetStream specifies a connector from Kafka to JetStream
+	KafkaToJetStream = "KafkaToJetStream"
+
 	// NATSToKafka specifies a connector from NATS to Kafka
 	NATSToKafka = "NATSToKafka"
 	// STANToKafka specifies a connector from NATS streaming to Kafka
 	STANToKafka = "STANToKafka"
+	// JetStreamToKafka specifies a connector from JetStream to Kafka
+	JetStreamToKafka = "JetStreamToKafka"
 )
 
 // NATSKafkaBridgeConfig is the root structure for a bridge configuration file.
@@ -68,6 +73,7 @@ type NATSKafkaBridgeConfig struct {
 	Logging    logging.Config
 	NATS       NATSConfig
 	STAN       NATSStreamingConfig
+	JetStream  JetStreamConfig
 	Monitoring HTTPConfig
 	Connect    []ConnectorConfig
 }
@@ -157,6 +163,15 @@ type NATSStreamingConfig struct {
 	ConnectWait        int // milliseconds
 }
 
+// JetStreamConfig configuration for a JetStream connection
+type JetStreamConfig struct {
+	PublishAsyncMaxPending int
+	MaxWait                int // milliseconds
+	EnableFlowControl      bool
+	EnableAckSync          bool
+	HeartbeatInterval      int // milliseconds
+}
+
 // DefaultBridgeConfig generates a default configuration with
 // logging set to colors, time, debug and trace
 func DefaultBridgeConfig() NATSKafkaBridgeConfig {
@@ -187,11 +202,11 @@ type ConnectorConfig struct {
 	Type string // Can be any of the type constants (STANToKafka, ...)
 
 	Channel         string // Used for stan connections
-	DurableName     string // Optional, used for stan connections
-	StartAtSequence int64  // Start position for stan connection, -1 means StartWithLastReceived, 0 means DeliverAllAvailable (default)
+	DurableName     string // Optional, used for stan and jetstream connections
+	StartAtSequence int64  // Start position for stan and jetstream connection, -1 means StartWithLastReceived, 0 means DeliverAllAvailable (default)
 	StartAtTime     int64  // Start time, as Unix, time takes precedence over sequence
 
-	Subject   string // Used for nats connections
+	Subject   string // Used for nats and jetstream connections
 	QueueName string // Optional, used for nats connections
 
 	Brokers []string // list of brokers to use for creating a reader/writer

--- a/server/core/jetstream2kafka.go
+++ b/server/core/jetstream2kafka.go
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2019-2021 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package core
+
+import (
+	"fmt"
+
+	"github.com/nats-io/nats-kafka/server/conf"
+	"github.com/nats-io/nats.go"
+)
+
+// JetStream2KafkaConnector connects a JetStream stream to Kafka
+type JetStream2KafkaConnector struct {
+	BridgeConnector
+	sub *nats.Subscription
+}
+
+// NewJetStream2KafkaConnector create a new stan to kafka
+func NewJetStream2KafkaConnector(bridge *NATSKafkaBridge, config conf.ConnectorConfig) Connector {
+	connector := &JetStream2KafkaConnector{}
+	connector.init(bridge, config, config.Topic, fmt.Sprintf("JetStream:%s to Kafka:%s", config.Subject, config.Topic))
+	return connector
+}
+
+// Start the connector
+func (conn *JetStream2KafkaConnector) Start() error {
+	conn.Lock()
+	defer conn.Unlock()
+
+	if !conn.bridge.CheckJetStream() {
+		return fmt.Errorf("%s connector requires JetStream to be available", conn.String())
+	}
+
+	conn.bridge.Logger().Tracef("starting connection %s", conn.String())
+
+	sub, err := conn.subscribeToJetStream(conn.config.Subject)
+	if err != nil {
+		return err
+	}
+	conn.sub = sub
+
+	conn.stats.AddConnect()
+	conn.bridge.Logger().Tracef("opened and reading %s", conn.config.Subject)
+	conn.bridge.Logger().Noticef("started connection %s", conn.String())
+
+	return nil
+}
+
+// Shutdown the connector
+func (conn *JetStream2KafkaConnector) Shutdown() error {
+	conn.Lock()
+	defer conn.Unlock()
+	conn.closeWriters()
+	conn.stats.AddDisconnect()
+
+	conn.bridge.Logger().Noticef("shutting down connection %s", conn.String())
+
+	if conn.sub != nil {
+		conn.bridge.Logger().Tracef("unsubscribing from %s", conn.config.Subject)
+		conn.sub.Unsubscribe()
+		conn.sub = nil
+	}
+
+	return nil
+}
+
+// CheckConnections ensures the nats/stan connection and report an error if it is down
+func (conn *JetStream2KafkaConnector) CheckConnections() error {
+	if !conn.bridge.CheckJetStream() {
+		return fmt.Errorf("%s connector requires nats streaming to be available", conn.String())
+	}
+	return nil
+}

--- a/server/core/jetstream2kafka_test.go
+++ b/server/core/jetstream2kafka_test.go
@@ -1,0 +1,888 @@
+/*
+ * Copyright 2019-2021 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package core
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats-kafka/server/conf"
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSimpleSendOnJetStreamReceiveOnKafka(t *testing.T) {
+	subject := nuid.Next()
+	topic := nuid.Next()
+	msg := "hello world"
+
+	connect := []conf.ConnectorConfig{
+		{
+			Type:    "JetStreamToKafka",
+			Subject: subject,
+			Topic:   topic,
+		},
+	}
+
+	tbs, err := StartTestEnvironment(connect)
+	require.NoError(t, err)
+	defer tbs.Close()
+
+	tbs.Bridge.checkConnections()
+
+	_, err = tbs.JS.Publish(subject, []byte(msg))
+	require.NoError(t, err)
+
+	reader := tbs.CreateReader(topic, 5000)
+	defer reader.Close()
+
+	_, data, err := tbs.GetMessageFromKafka(reader, 5000)
+	require.NoError(t, err)
+	require.Equal(t, msg, string(data))
+
+	stats := tbs.Bridge.SafeStats()
+	connStats := stats.Connections[0]
+	require.Equal(t, int64(1), connStats.MessagesIn)
+	require.Equal(t, int64(1), connStats.MessagesOut)
+	require.Equal(t, int64(len([]byte(msg))), connStats.BytesIn)
+	require.Equal(t, int64(len([]byte(msg))), connStats.BytesOut)
+	require.Equal(t, int64(1), connStats.Connects)
+	require.Equal(t, int64(0), connStats.Disconnects)
+	require.True(t, connStats.Connected)
+}
+
+func TestSimpleSASLSendOnJetStreamReceiveOnKafka(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
+	subject := nuid.Next()
+	topic := nuid.Next()
+	msg := "hello world"
+
+	connect := []conf.ConnectorConfig{
+		{
+			Type:    "JetStreamToKafka",
+			Subject: subject,
+			Topic:   topic,
+			SASL: conf.SASL{
+				User:     saslUser,
+				Password: saslPassword,
+			},
+		},
+	}
+
+	tbs, err := StartSASLTestEnvironment(connect)
+	require.NoError(t, err)
+	defer tbs.Close()
+
+	tbs.Bridge.checkConnections()
+
+	_, err = tbs.JS.Publish(subject, []byte(msg))
+	require.NoError(t, err)
+
+	reader := tbs.CreateReader(topic, 5000)
+	defer reader.Close()
+
+	_, data, err := tbs.GetMessageFromKafka(reader, 5000)
+	require.NoError(t, err)
+	require.Equal(t, msg, string(data))
+
+	stats := tbs.Bridge.SafeStats()
+	connStats := stats.Connections[0]
+	require.Equal(t, int64(1), connStats.MessagesIn)
+	require.Equal(t, int64(1), connStats.MessagesOut)
+	require.Equal(t, int64(len([]byte(msg))), connStats.BytesIn)
+	require.Equal(t, int64(len([]byte(msg))), connStats.BytesOut)
+	require.Equal(t, int64(1), connStats.Connects)
+	require.Equal(t, int64(0), connStats.Disconnects)
+	require.True(t, connStats.Connected)
+}
+
+func TestJetStreamQueueStartAtPosition(t *testing.T) {
+	subject := nuid.Next()
+	topic := nuid.Next()
+	msg := "hello world"
+	msg2 := "goodbye world"
+
+	connect := []conf.ConnectorConfig{
+		{
+			Type:            "JetStreamToKafka",
+			Subject:         subject,
+			Topic:           topic,
+			StartAtSequence: 2,
+		},
+	}
+
+	tbs, err := StartTestEnvironmentInfrastructure(false, false, []string{topic})
+	require.NoError(t, err)
+	defer tbs.Close()
+
+	_, err = tbs.JS.AddStream(&nats.StreamConfig{
+		Name:     nuid.Next(),
+		Subjects: []string{subject},
+	})
+	require.NoError(t, err)
+
+	// Send 2 messages, should only get 2nd
+	_, err = tbs.JS.Publish(subject, []byte(msg))
+	require.NoError(t, err)
+	_, err = tbs.JS.Publish(subject, []byte(msg2))
+	require.NoError(t, err)
+
+	err = tbs.StartBridge(connect)
+	require.NoError(t, err)
+
+	reader := tbs.CreateReader(topic, 5000)
+	defer reader.Close()
+
+	_, data, err := tbs.GetMessageFromKafka(reader, 5000)
+	require.NoError(t, err)
+	require.Equal(t, msg2, string(data))
+	_, _, err = tbs.GetMessageFromKafka(reader, 2000)
+	require.Error(t, err)
+
+	stats := tbs.Bridge.SafeStats()
+	connStats := stats.Connections[0]
+	require.Equal(t, int64(1), connStats.MessagesIn)
+	require.Equal(t, int64(1), connStats.MessagesOut)
+}
+
+func TestSASLJetStreamQueueStartAtPosition(t *testing.T) {
+	subject := nuid.Next()
+	topic := nuid.Next()
+	msg := "hello world"
+	msg2 := "goodbye world"
+
+	connect := []conf.ConnectorConfig{
+		{
+			Type:            "JetStreamToKafka",
+			Subject:         subject,
+			Topic:           topic,
+			StartAtSequence: 2,
+			SASL: conf.SASL{
+				User:     saslUser,
+				Password: saslPassword,
+			},
+		},
+	}
+
+	tbs, err := StartTestEnvironmentInfrastructure(true, false, []string{topic})
+	require.NoError(t, err)
+	defer tbs.Close()
+
+	_, err = tbs.JS.AddStream(&nats.StreamConfig{
+		Name:     nuid.Next(),
+		Subjects: []string{subject},
+	})
+	require.NoError(t, err)
+
+	// Send 2 messages, should only get 2nd
+	_, err = tbs.JS.Publish(subject, []byte(msg))
+	require.NoError(t, err)
+	_, err = tbs.JS.Publish(subject, []byte(msg2))
+	require.NoError(t, err)
+
+	err = tbs.StartBridge(connect)
+	require.NoError(t, err)
+
+	reader := tbs.CreateReader(topic, 5000)
+	defer reader.Close()
+
+	_, data, err := tbs.GetMessageFromKafka(reader, 5000)
+	require.NoError(t, err)
+	require.Equal(t, msg2, string(data))
+	_, _, err = tbs.GetMessageFromKafka(reader, 2000)
+	require.Error(t, err)
+
+	stats := tbs.Bridge.SafeStats()
+	connStats := stats.Connections[0]
+	require.Equal(t, int64(1), connStats.MessagesIn)
+	require.Equal(t, int64(1), connStats.MessagesOut)
+}
+
+func TestJetStreamQueueDeliverLatest(t *testing.T) {
+	subject := nuid.Next()
+	topic := nuid.Next()
+	msg := "hello world"
+
+	connect := []conf.ConnectorConfig{
+		{
+			Type:            "JetStreamToKafka",
+			Subject:         subject,
+			Topic:           topic,
+			StartAtSequence: -1,
+		},
+	}
+
+	tbs, err := StartTestEnvironmentInfrastructure(false, false, []string{topic})
+	require.NoError(t, err)
+	defer tbs.Close()
+
+	_, err = tbs.JS.AddStream(&nats.StreamConfig{
+		Name:     nuid.Next(),
+		Subjects: []string{subject},
+	})
+	require.NoError(t, err)
+
+	// Send 2 messages, should only get 2nd
+	_, err = tbs.JS.Publish(subject, []byte(msg))
+	require.NoError(t, err)
+	_, err = tbs.JS.Publish(subject, []byte(msg))
+	require.NoError(t, err)
+
+	err = tbs.StartBridge(connect)
+	require.NoError(t, err)
+
+	reader := tbs.CreateReader(topic, 5000)
+	defer reader.Close()
+
+	// Should get the last one
+	_, _, err = tbs.GetMessageFromKafka(reader, 5000)
+	require.NoError(t, err)
+
+	_, err = tbs.JS.Publish(subject, []byte(msg))
+	require.NoError(t, err)
+
+	// Should receive 1 message we just sent
+	_, _, err = tbs.GetMessageFromKafka(reader, 5000)
+	require.NoError(t, err)
+	_, _, err = tbs.GetMessageFromKafka(reader, 3000)
+	require.Error(t, err)
+
+	stats := tbs.Bridge.SafeStats()
+	connStats := stats.Connections[0]
+	require.Equal(t, int64(2), connStats.MessagesIn)
+	require.Equal(t, int64(2), connStats.MessagesOut)
+}
+
+func TestJetStreamSASLQueueDeliverLatest(t *testing.T) {
+	subject := nuid.Next()
+	topic := nuid.Next()
+	msg := "hello world"
+
+	connect := []conf.ConnectorConfig{
+		{
+			Type:            "JetStreamToKafka",
+			Subject:         subject,
+			Topic:           topic,
+			StartAtSequence: -1,
+			SASL: conf.SASL{
+				User:     saslUser,
+				Password: saslPassword,
+			},
+		},
+	}
+
+	tbs, err := StartTestEnvironmentInfrastructure(true, false, []string{topic})
+	require.NoError(t, err)
+	defer tbs.Close()
+
+	_, err = tbs.JS.AddStream(&nats.StreamConfig{
+		Name:     nuid.Next(),
+		Subjects: []string{subject},
+	})
+	require.NoError(t, err)
+
+	// Send 2 messages, should only get 2nd
+	_, err = tbs.JS.Publish(subject, []byte(msg))
+	require.NoError(t, err)
+	_, err = tbs.JS.Publish(subject, []byte(msg))
+	require.NoError(t, err)
+
+	err = tbs.StartBridge(connect)
+	require.NoError(t, err)
+
+	reader := tbs.CreateReader(topic, 5000)
+	defer reader.Close()
+
+	// Should get the last one
+	_, _, err = tbs.GetMessageFromKafka(reader, 5000)
+	require.NoError(t, err)
+
+	_, err = tbs.JS.Publish(subject, []byte(msg))
+	require.NoError(t, err)
+
+	// Should receive 1 message we just sent
+	_, _, err = tbs.GetMessageFromKafka(reader, 5000)
+	require.NoError(t, err)
+	_, _, err = tbs.GetMessageFromKafka(reader, 3000)
+	require.Error(t, err)
+
+	stats := tbs.Bridge.SafeStats()
+	connStats := stats.Connections[0]
+	require.Equal(t, int64(2), connStats.MessagesIn)
+	require.Equal(t, int64(2), connStats.MessagesOut)
+}
+
+func TestJetStreamQueueStartAtTime(t *testing.T) {
+	subject := nuid.Next()
+	topic := nuid.Next()
+	msg := "hello world"
+
+	tbs, err := StartTestEnvironmentInfrastructure(false, false, []string{topic})
+	require.NoError(t, err)
+	defer tbs.Close()
+
+	_, err = tbs.JS.AddStream(&nats.StreamConfig{
+		Name:     nuid.Next(),
+		Subjects: []string{subject},
+	})
+	require.NoError(t, err)
+
+	// Send 2 messages, should only get 2nd
+	_, err = tbs.JS.Publish(subject, []byte(msg))
+	require.NoError(t, err)
+	_, err = tbs.JS.Publish(subject, []byte(msg))
+	require.NoError(t, err)
+
+	time.Sleep(2 * time.Second) // move the time along
+
+	connect := []conf.ConnectorConfig{
+		{
+			Type:        "JetStreamToKafka",
+			Subject:     subject,
+			Topic:       topic,
+			StartAtTime: time.Now().Unix(),
+		},
+	}
+
+	err = tbs.StartBridge(connect)
+	require.NoError(t, err)
+
+	time.Sleep(1 * time.Second) // move the time along
+
+	_, err = tbs.JS.Publish(subject, []byte(msg))
+	require.NoError(t, err)
+
+	reader := tbs.CreateReader(topic, 5000)
+	defer reader.Close()
+
+	// Should only get the one we just sent
+	_, _, err = tbs.GetMessageFromKafka(reader, 5000)
+	require.NoError(t, err)
+	_, _, err = tbs.GetMessageFromKafka(reader, 3000)
+	require.Error(t, err)
+
+	stats := tbs.Bridge.SafeStats()
+	connStats := stats.Connections[0]
+	require.Equal(t, int64(1), connStats.MessagesIn)
+	require.Equal(t, int64(1), connStats.MessagesOut)
+}
+
+func TestJetStreamSASLQueueStartAtTime(t *testing.T) {
+	subject := nuid.Next()
+	topic := nuid.Next()
+	msg := "hello world"
+
+	tbs, err := StartTestEnvironmentInfrastructure(true, false, []string{topic})
+	require.NoError(t, err)
+	defer tbs.Close()
+
+	_, err = tbs.JS.AddStream(&nats.StreamConfig{
+		Name:     nuid.Next(),
+		Subjects: []string{subject},
+	})
+	require.NoError(t, err)
+
+	// Send 2 messages, should only get 2nd
+	_, err = tbs.JS.Publish(subject, []byte(msg))
+	require.NoError(t, err)
+	_, err = tbs.JS.Publish(subject, []byte(msg))
+	require.NoError(t, err)
+
+	time.Sleep(2 * time.Second) // move the time along
+
+	connect := []conf.ConnectorConfig{
+		{
+			Type:        "JetStreamToKafka",
+			Subject:     subject,
+			Topic:       topic,
+			StartAtTime: time.Now().Unix(),
+			SASL: conf.SASL{
+				User:     saslUser,
+				Password: saslPassword,
+			},
+		},
+	}
+
+	err = tbs.StartBridge(connect)
+	require.NoError(t, err)
+
+	time.Sleep(1 * time.Second) // move the time along
+
+	_, err = tbs.JS.Publish(subject, []byte(msg))
+	require.NoError(t, err)
+
+	reader := tbs.CreateReader(topic, 5000)
+	defer reader.Close()
+
+	// Should only get the one we just sent
+	_, _, err = tbs.GetMessageFromKafka(reader, 5000)
+	require.NoError(t, err)
+	_, _, err = tbs.GetMessageFromKafka(reader, 3000)
+	require.Error(t, err)
+
+	stats := tbs.Bridge.SafeStats()
+	connStats := stats.Connections[0]
+	require.Equal(t, int64(1), connStats.MessagesIn)
+	require.Equal(t, int64(1), connStats.MessagesOut)
+}
+
+func TestJetStreamQueueDurableSubscriber(t *testing.T) {
+	subject := nuid.Next()
+	topic := nuid.Next()
+
+	tbs, err := StartTestEnvironmentInfrastructure(false, false, []string{topic})
+	require.NoError(t, err)
+	defer tbs.Close()
+
+	stream := nuid.Next()
+	_, err = tbs.JS.AddStream(&nats.StreamConfig{
+		Name:     stream,
+		Subjects: []string{subject},
+	})
+	require.NoError(t, err)
+	durable := nuid.Next()
+	_, err = tbs.JS.AddConsumer(stream, &nats.ConsumerConfig{
+		Durable:        durable,
+		AckPolicy:      nats.AckExplicitPolicy,
+		DeliverSubject: "foo",
+	})
+	require.NoError(t, err)
+
+	connect := []conf.ConnectorConfig{
+		{
+			Type:            "JetStreamToKafka",
+			Subject:         subject,
+			Topic:           topic,
+			DurableName:     durable,
+			StartAtSequence: 2,
+		},
+	}
+
+	err = tbs.StartBridge(connect)
+	require.NoError(t, err)
+
+	_, err = tbs.JS.Publish(subject, []byte("one"))
+	require.NoError(t, err)
+
+	tbs.WaitForRequests(1) // get that request through the system
+
+	tbs.StopBridge()
+
+	_, err = tbs.JS.Publish(subject, []byte("two"))
+	require.NoError(t, err)
+
+	_, err = tbs.JS.Publish(subject, []byte("three"))
+	require.NoError(t, err)
+
+	err = tbs.StartBridge(connect)
+	require.NoError(t, err)
+
+	reader := tbs.CreateReader(topic, 5000)
+	defer reader.Close()
+
+	// should get three, even though we stopped the bridge
+	_, _, err = tbs.GetMessageFromKafka(reader, 5000)
+	require.NoError(t, err)
+	_, _, err = tbs.GetMessageFromKafka(reader, 5000)
+	require.NoError(t, err)
+	_, _, err = tbs.GetMessageFromKafka(reader, 5000)
+	require.NoError(t, err)
+	_, _, err = tbs.GetMessageFromKafka(reader, 2000)
+	require.Error(t, err)
+
+	tbs.WaitForRequests(2) // get the later requests through the system
+
+	// Should have 2 messages since the relaunch
+	stats := tbs.Bridge.SafeStats()
+	connStats := stats.Connections[0]
+	require.Equal(t, int64(2), connStats.MessagesIn)
+	require.Equal(t, int64(2), connStats.MessagesOut)
+}
+
+func TestJetStreamSASLQueueDurableSubscriber(t *testing.T) {
+	subject := nuid.Next()
+	topic := nuid.Next()
+
+	tbs, err := StartTestEnvironmentInfrastructure(true, false, []string{topic})
+	require.NoError(t, err)
+	defer tbs.Close()
+
+	stream := nuid.Next()
+	_, err = tbs.JS.AddStream(&nats.StreamConfig{
+		Name:     stream,
+		Subjects: []string{subject},
+	})
+	require.NoError(t, err)
+	durable := nuid.Next()
+	_, err = tbs.JS.AddConsumer(stream, &nats.ConsumerConfig{
+		Durable:        durable,
+		AckPolicy:      nats.AckExplicitPolicy,
+		DeliverSubject: "foo",
+	})
+	require.NoError(t, err)
+
+	connect := []conf.ConnectorConfig{
+		{
+			Type:            "JetStreamToKafka",
+			Subject:         subject,
+			Topic:           topic,
+			DurableName:     durable,
+			StartAtSequence: 2,
+			SASL: conf.SASL{
+				User:     saslUser,
+				Password: saslPassword,
+			},
+		},
+	}
+
+	err = tbs.StartBridge(connect)
+	require.NoError(t, err)
+
+	_, err = tbs.JS.Publish(subject, []byte("one"))
+	require.NoError(t, err)
+
+	tbs.WaitForRequests(1) // get that request through the system
+
+	tbs.StopBridge()
+
+	_, err = tbs.JS.Publish(subject, []byte("two"))
+	require.NoError(t, err)
+
+	_, err = tbs.JS.Publish(subject, []byte("three"))
+	require.NoError(t, err)
+
+	err = tbs.StartBridge(connect)
+	require.NoError(t, err)
+
+	reader := tbs.CreateReader(topic, 5000)
+	defer reader.Close()
+
+	// should get three, even though we stopped the bridge
+	_, _, err = tbs.GetMessageFromKafka(reader, 5000)
+	require.NoError(t, err)
+	_, _, err = tbs.GetMessageFromKafka(reader, 5000)
+	require.NoError(t, err)
+	_, _, err = tbs.GetMessageFromKafka(reader, 5000)
+	require.NoError(t, err)
+	_, _, err = tbs.GetMessageFromKafka(reader, 2000)
+	require.Error(t, err)
+
+	tbs.WaitForRequests(2) // get the later requests through the system
+
+	// Should have 2 messages since the relaunch
+	stats := tbs.Bridge.SafeStats()
+	connStats := stats.Connections[0]
+	require.Equal(t, int64(2), connStats.MessagesIn)
+	require.Equal(t, int64(2), connStats.MessagesOut)
+}
+
+func TestSimpleSendOnJetStreamReceiveOnKafkaWithTLS(t *testing.T) {
+	subject := nuid.Next()
+	topic := nuid.Next()
+	msg := "hello world"
+
+	connect := []conf.ConnectorConfig{
+		{
+			Type:    "JetStreamToKafka",
+			Subject: subject,
+			Topic:   topic,
+		},
+	}
+
+	tbs, err := StartTLSTestEnvironment(connect)
+	require.NoError(t, err)
+	defer tbs.Close()
+
+	_, err = tbs.JS.Publish(subject, []byte(msg))
+	require.NoError(t, err)
+
+	reader := tbs.CreateReader(topic, 5000)
+	defer reader.Close()
+
+	_, data, err := tbs.GetMessageFromKafka(reader, 5000)
+	require.NoError(t, err)
+	require.Equal(t, msg, string(data))
+}
+
+func TestFixedKeyFromJetStream(t *testing.T) {
+	subject := nuid.Next()
+	topic := nuid.Next()
+	msg := "hello world"
+
+	connect := []conf.ConnectorConfig{
+		{
+			Type:     "JetStreamToKafka",
+			Subject:  subject,
+			Topic:    topic,
+			KeyType:  "fixed",
+			KeyValue: "alpha",
+		},
+	}
+
+	tbs, err := StartTestEnvironment(connect)
+	require.NoError(t, err)
+	defer tbs.Close()
+
+	_, err = tbs.JS.Publish(subject, []byte(msg))
+	require.NoError(t, err)
+
+	reader := tbs.CreateReader(topic, 5000)
+	defer reader.Close()
+
+	key, data, err := tbs.GetMessageFromKafka(reader, 5000)
+	require.NoError(t, err)
+	require.Equal(t, msg, string(data))
+	require.Equal(t, "alpha", string(key))
+}
+
+func TestSASLFixedKeyFromJetStream(t *testing.T) {
+	subject := nuid.Next()
+	topic := nuid.Next()
+	msg := "hello world"
+
+	connect := []conf.ConnectorConfig{
+		{
+			Type:     "JetStreamToKafka",
+			Subject:  subject,
+			Topic:    topic,
+			KeyType:  "fixed",
+			KeyValue: "alpha",
+			SASL: conf.SASL{
+				User:     saslUser,
+				Password: saslPassword,
+			},
+		},
+	}
+
+	tbs, err := StartSASLTestEnvironment(connect)
+	require.NoError(t, err)
+	defer tbs.Close()
+
+	_, err = tbs.JS.Publish(subject, []byte(msg))
+	require.NoError(t, err)
+
+	reader := tbs.CreateReader(topic, 5000)
+	defer reader.Close()
+
+	key, data, err := tbs.GetMessageFromKafka(reader, 5000)
+	require.NoError(t, err)
+	require.Equal(t, msg, string(data))
+	require.Equal(t, "alpha", string(key))
+}
+
+func TestSubjectKeyFromJetStream(t *testing.T) {
+	subject := nuid.Next()
+	topic := nuid.Next()
+	msg := "hello world"
+
+	connect := []conf.ConnectorConfig{
+		{
+			Type:    "JetStreamToKafka",
+			Subject: subject,
+			Topic:   topic,
+			KeyType: "subject",
+		},
+	}
+
+	tbs, err := StartTestEnvironment(connect)
+	require.NoError(t, err)
+	defer tbs.Close()
+
+	_, err = tbs.JS.Publish(subject, []byte(msg))
+	require.NoError(t, err)
+
+	reader := tbs.CreateReader(topic, 5000)
+	defer reader.Close()
+
+	key, data, err := tbs.GetMessageFromKafka(reader, 5000)
+	require.NoError(t, err)
+	require.Equal(t, msg, string(data))
+	require.Equal(t, subject, string(key))
+}
+
+func TestSASLSubjectKeyFromJetStream(t *testing.T) {
+	subject := nuid.Next()
+	topic := nuid.Next()
+	msg := "hello world"
+
+	connect := []conf.ConnectorConfig{
+		{
+			Type:    "JetStreamToKafka",
+			Subject: subject,
+			Topic:   topic,
+			KeyType: "subject",
+			SASL: conf.SASL{
+				User:     saslUser,
+				Password: saslPassword,
+			},
+		},
+	}
+
+	tbs, err := StartSASLTestEnvironment(connect)
+	require.NoError(t, err)
+	defer tbs.Close()
+
+	_, err = tbs.JS.Publish(subject, []byte(msg))
+	require.NoError(t, err)
+
+	reader := tbs.CreateReader(topic, 5000)
+	defer reader.Close()
+
+	key, data, err := tbs.GetMessageFromKafka(reader, 5000)
+	require.NoError(t, err)
+	require.Equal(t, msg, string(data))
+	require.Equal(t, subject, string(key))
+}
+
+func TestSubjectRegexKeyFromJetStream(t *testing.T) {
+	prefix := nuid.Next()
+	topic := nuid.Next()
+	msg := "hello world"
+
+	connect := []conf.ConnectorConfig{
+		{
+			Type:     "JetStreamToKafka",
+			Subject:  fmt.Sprintf("%s.alpha", prefix),
+			Topic:    topic,
+			KeyType:  "subjectre",
+			KeyValue: fmt.Sprintf("%s\\.([^.]+)", prefix),
+		},
+	}
+
+	tbs, err := StartTestEnvironment(connect)
+	require.NoError(t, err)
+	defer tbs.Close()
+
+	_, err = tbs.JS.Publish(fmt.Sprintf("%s.alpha", prefix), []byte(msg))
+	require.NoError(t, err)
+
+	reader := tbs.CreateReader(topic, 5000)
+	defer reader.Close()
+
+	key, data, err := tbs.GetMessageFromKafka(reader, 5000)
+	require.NoError(t, err)
+	require.Equal(t, msg, string(data))
+	require.Equal(t, "alpha", string(key))
+}
+
+func TestSASLSubjectRegexKeyFromJetStream(t *testing.T) {
+	prefix := nuid.Next()
+	topic := nuid.Next()
+	msg := "hello world"
+
+	connect := []conf.ConnectorConfig{
+		{
+			Type:     "JetStreamToKafka",
+			Subject:  fmt.Sprintf("%s.alpha", prefix),
+			Topic:    topic,
+			KeyType:  "subjectre",
+			KeyValue: fmt.Sprintf("%s\\.([^.]+)", prefix),
+			SASL: conf.SASL{
+				User:     saslUser,
+				Password: saslPassword,
+			},
+		},
+	}
+
+	tbs, err := StartSASLTestEnvironment(connect)
+	require.NoError(t, err)
+	defer tbs.Close()
+
+	_, err = tbs.JS.Publish(fmt.Sprintf("%s.alpha", prefix), []byte(msg))
+	require.NoError(t, err)
+
+	reader := tbs.CreateReader(topic, 5000)
+	defer reader.Close()
+
+	key, data, err := tbs.GetMessageFromKafka(reader, 5000)
+	require.NoError(t, err)
+	require.Equal(t, msg, string(data))
+	require.Equal(t, "alpha", string(key))
+}
+
+func TestReplyKeyFromJetStream(t *testing.T) {
+	subject := nuid.Next()
+	durable := nuid.Next()
+	topic := nuid.Next()
+	msg := "hello world"
+
+	connect := []conf.ConnectorConfig{
+		{
+			Type:        "JetStreamToKafka",
+			Subject:     subject,
+			DurableName: durable,
+			Topic:       topic,
+			KeyType:     "reply",
+		},
+	}
+
+	tbs, err := StartTestEnvironment(connect)
+	require.NoError(t, err)
+	defer tbs.Close()
+
+	_, err = tbs.JS.Publish(subject, []byte(msg))
+	require.NoError(t, err)
+
+	reader := tbs.CreateReader(topic, 5000)
+	defer reader.Close()
+
+	key, data, err := tbs.GetMessageFromKafka(reader, 5000)
+	require.NoError(t, err)
+	require.Equal(t, msg, string(data))
+	require.Equal(t, durable, string(key))
+}
+
+func TestSASLReplyKeyFromJetStream(t *testing.T) {
+	subject := nuid.Next()
+	durable := nuid.Next()
+	topic := nuid.Next()
+	msg := "hello world"
+
+	connect := []conf.ConnectorConfig{
+		{
+			Type:        "JetStreamToKafka",
+			Subject:     subject,
+			DurableName: durable,
+			Topic:       topic,
+			KeyType:     "reply",
+			SASL: conf.SASL{
+				User:     saslUser,
+				Password: saslPassword,
+			},
+		},
+	}
+
+	tbs, err := StartSASLTestEnvironment(connect)
+	require.NoError(t, err)
+	defer tbs.Close()
+
+	_, err = tbs.JS.Publish(subject, []byte(msg))
+	require.NoError(t, err)
+
+	reader := tbs.CreateReader(topic, 5000)
+	defer reader.Close()
+
+	key, data, err := tbs.GetMessageFromKafka(reader, 5000)
+	require.NoError(t, err)
+	require.Equal(t, msg, string(data))
+	require.Equal(t, durable, string(key))
+}

--- a/server/core/kafka2jetstream.go
+++ b/server/core/kafka2jetstream.go
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2019-2021 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package core
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/nats-io/nats-kafka/server/conf"
+	"github.com/nats-io/nats-kafka/server/kafka"
+)
+
+// Kafka2JetStreamConnector connects Kafka topic to JetStream
+type Kafka2JetStreamConnector struct {
+	BridgeConnector
+
+	reader     kafka.Consumer
+	shutdownCB ShutdownCallback
+}
+
+// NewKafka2JetStreamConnector create a new Kafka to JetStream connector
+func NewKafka2JetStreamConnector(bridge *NATSKafkaBridge, config conf.ConnectorConfig) Connector {
+	connector := &Kafka2JetStreamConnector{}
+	connector.init(bridge, config, config.Subject, fmt.Sprintf("Kafka:%s to JetStream:%s", config.Topic, config.Subject))
+	return connector
+}
+
+// Start the connector
+func (conn *Kafka2JetStreamConnector) Start() error {
+	conn.Lock()
+	defer conn.Unlock()
+
+	if !conn.bridge.CheckJetStream() {
+		return fmt.Errorf("%s connector requires JetStream to be available", conn.String())
+	}
+
+	conn.bridge.Logger().Tracef("starting connection %s", conn.String())
+
+	var err error
+	dialTimeout := time.Duration(conn.bridge.config.ConnectTimeout) * time.Millisecond
+	conn.reader, err = kafka.NewConsumer(conn.config, dialTimeout)
+	if err != nil {
+		return fmt.Errorf("failed to create consumer: %w", err)
+	}
+	if s, ok := conn.reader.(interface{ NetInfo() string }); ok {
+		conn.bridge.Logger().Noticef(s.NetInfo())
+	}
+
+	cb, err := conn.setUpListener(conn.reader, conn.jetStreamMessageHandler)
+	if err != nil {
+		return err
+	}
+	conn.shutdownCB = cb
+
+	conn.stats.AddConnect()
+	conn.bridge.Logger().Tracef("opened and reading %s", conn.config.Topic)
+	conn.bridge.Logger().Noticef("started connection %s", conn.String())
+
+	return nil
+}
+
+// Shutdown the connector
+func (conn *Kafka2JetStreamConnector) Shutdown() error {
+	conn.Lock()
+	defer conn.Unlock()
+	conn.closeWriters()
+	conn.stats.AddDisconnect()
+
+	conn.bridge.Logger().Noticef("shutting down connection %s", conn.String())
+
+	if conn.shutdownCB != nil {
+		if err := conn.shutdownCB(); err != nil {
+			conn.bridge.Logger().Noticef("error stopping listen routine for %s, %s", conn.String(), err.Error())
+		}
+		conn.shutdownCB = nil
+	}
+
+	reader := conn.reader
+	conn.reader = nil
+
+	if reader != nil {
+		if err := reader.Close(); err != nil {
+			conn.bridge.Logger().Noticef("error closing reader for %s, %s", conn.String(), err.Error())
+		}
+	}
+
+	return nil // ignore the disconnect error
+}
+
+// CheckConnections ensures the nats/stan connection and report an error if it is down
+func (conn *Kafka2JetStreamConnector) CheckConnections() error {
+	if !conn.bridge.CheckJetStream() {
+		return fmt.Errorf("%s connector requires nats streaming to be available", conn.String())
+	}
+	return nil
+}

--- a/server/core/kafka2jetstream_test.go
+++ b/server/core/kafka2jetstream_test.go
@@ -1,0 +1,255 @@
+/*
+ * Copyright 2019-2021 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package core
+
+import (
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats-kafka/server/conf"
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSimpleSendOnKafkaReceiveOnJetStream(t *testing.T) {
+	subject := nuid.Next()
+	topic := nuid.Next()
+	msg := "hello world"
+
+	connect := []conf.ConnectorConfig{
+		{
+			Type:    "KafkaToJetStream",
+			Subject: subject,
+			Topic:   topic,
+		},
+	}
+
+	tbs, err := StartTestEnvironment(connect)
+	require.NoError(t, err)
+	defer tbs.Close()
+
+	tbs.Bridge.checkConnections()
+
+	done := make(chan string)
+
+	sub, err := tbs.JS.Subscribe(subject, func(msg *nats.Msg) {
+		done <- string(msg.Data)
+	})
+	require.NoError(t, err)
+	defer sub.Unsubscribe()
+
+	err = tbs.SendMessageToKafka(topic, []byte(msg), 5000)
+	require.NoError(t, err)
+
+	received := tbs.WaitForIt(1, done)
+	require.Equal(t, msg, received)
+
+	stats := tbs.Bridge.SafeStats()
+	connStats := stats.Connections[0]
+	require.Equal(t, int64(1), connStats.MessagesIn)
+	require.Equal(t, int64(1), connStats.MessagesOut)
+	require.Equal(t, int64(len([]byte(msg))), connStats.BytesIn)
+	require.Equal(t, int64(len([]byte(msg))), connStats.BytesOut)
+	require.Equal(t, int64(1), connStats.Connects)
+	require.Equal(t, int64(0), connStats.Disconnects)
+	require.True(t, connStats.Connected)
+}
+
+func TestSimpleSASLSendOnKafkaReceiveOnJetStream(t *testing.T) {
+	subject := nuid.Next()
+	topic := nuid.Next()
+	msg := "hello world"
+
+	connect := []conf.ConnectorConfig{
+		{
+			Type:    "KafkaToJetStream",
+			Subject: subject,
+			Topic:   topic,
+			SASL: conf.SASL{
+				User:     saslUser,
+				Password: saslPassword,
+			},
+		},
+	}
+
+	tbs, err := StartSASLTestEnvironment(connect)
+	require.NoError(t, err)
+	defer tbs.Close()
+
+	tbs.Bridge.checkConnections()
+
+	done := make(chan string)
+
+	sub, err := tbs.JS.Subscribe(subject, func(msg *nats.Msg) {
+		done <- string(msg.Data)
+	})
+	require.NoError(t, err)
+	defer sub.Unsubscribe()
+
+	err = tbs.SendMessageToKafka(topic, []byte(msg), 5000)
+	require.NoError(t, err)
+
+	received := tbs.WaitForIt(1, done)
+	require.Equal(t, msg, received)
+
+	stats := tbs.Bridge.SafeStats()
+	connStats := stats.Connections[0]
+	require.Equal(t, int64(1), connStats.MessagesIn)
+	require.Equal(t, int64(1), connStats.MessagesOut)
+	require.Equal(t, int64(len([]byte(msg))), connStats.BytesIn)
+	require.Equal(t, int64(len([]byte(msg))), connStats.BytesOut)
+	require.Equal(t, int64(1), connStats.Connects)
+	require.Equal(t, int64(0), connStats.Disconnects)
+	require.True(t, connStats.Connected)
+}
+
+func TestSimpleSendOnKafkaReceiveOnJetStreamWithGroup(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
+	subject := nuid.Next()
+	topic := nuid.Next()
+	group := "group-1"
+	msg := "hello world"
+
+	connect := []conf.ConnectorConfig{
+		{
+			Type:    "KafkaToJetStream",
+			Subject: subject,
+			Topic:   topic,
+			GroupID: group,
+		},
+	}
+
+	tbs, err := StartTestEnvironment(connect)
+	require.NoError(t, err)
+	defer tbs.Close()
+
+	// This test almost always fails if we don't wait a bit here.
+	// It has probably something to do with some initialization in Kafka,
+	// but I am not sure what. This delay is not bullet proof but at least helps.
+	time.Sleep(time.Second)
+
+	done := make(chan string)
+
+	sub, err := tbs.JS.Subscribe(subject, func(msg *nats.Msg) {
+		done <- string(msg.Data)
+	})
+	require.NoError(t, err)
+	defer sub.Unsubscribe()
+
+	err = tbs.SendMessageToKafka(topic, []byte(msg), 5000)
+	require.NoError(t, err)
+
+	received := tbs.WaitForIt(1, done)
+	require.Equal(t, msg, received)
+
+	stats := tbs.Bridge.SafeStats()
+	connStats := stats.Connections[0]
+	require.Equal(t, int64(1), connStats.MessagesIn)
+	require.Equal(t, int64(1), connStats.MessagesOut)
+	require.Equal(t, int64(len([]byte(msg))), connStats.BytesIn)
+	require.Equal(t, int64(len([]byte(msg))), connStats.BytesOut)
+	require.Equal(t, int64(1), connStats.Connects)
+	require.Equal(t, int64(0), connStats.Disconnects)
+	require.True(t, connStats.Connected)
+}
+
+func TestSimpleSASLSendOnKafkaReceiveOnJetStreamWithGroup(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
+	subject := nuid.Next()
+	topic := nuid.Next()
+	group := "group-1"
+	msg := "hello world"
+
+	connect := []conf.ConnectorConfig{
+		{
+			Type:    "KafkaToJetStream",
+			Subject: subject,
+			Topic:   topic,
+			GroupID: group,
+			SASL: conf.SASL{
+				User:     saslUser,
+				Password: saslPassword,
+			},
+		},
+	}
+
+	tbs, err := StartSASLTestEnvironment(connect)
+	require.NoError(t, err)
+	defer tbs.Close()
+
+	done := make(chan string)
+
+	sub, err := tbs.NC.Subscribe(subject, func(msg *nats.Msg) {
+		done <- string(msg.Data)
+	})
+	require.NoError(t, err)
+	defer sub.Unsubscribe()
+
+	err = tbs.SendMessageToKafka(topic, []byte(msg), 5000)
+	require.NoError(t, err)
+
+	received := tbs.WaitForIt(1, done)
+	require.Equal(t, msg, received)
+
+	stats := tbs.Bridge.SafeStats()
+	connStats := stats.Connections[0]
+	require.Equal(t, int64(1), connStats.MessagesIn)
+	require.Equal(t, int64(1), connStats.MessagesOut)
+	require.Equal(t, int64(len([]byte(msg))), connStats.BytesIn)
+	require.Equal(t, int64(len([]byte(msg))), connStats.BytesOut)
+	require.Equal(t, int64(1), connStats.Connects)
+	require.Equal(t, int64(0), connStats.Disconnects)
+	require.True(t, connStats.Connected)
+}
+
+func TestSimpleSendOnQueueReceiveOnJetStreamWithTLS(t *testing.T) {
+	subject := nuid.Next()
+	topic := nuid.Next()
+	msg := "hello world"
+
+	connect := []conf.ConnectorConfig{
+		{
+			Type:    "KafkaToJetStream",
+			Subject: subject,
+			Topic:   topic,
+		},
+	}
+
+	tbs, err := StartTLSTestEnvironment(connect)
+	require.NoError(t, err)
+	defer tbs.Close()
+
+	done := make(chan string)
+
+	sub, err := tbs.JS.Subscribe(subject, func(msg *nats.Msg) {
+		done <- string(msg.Data)
+	})
+	require.NoError(t, err)
+	defer sub.Unsubscribe()
+
+	err = tbs.SendMessageToKafka(topic, []byte(msg), 5000)
+	require.NoError(t, err)
+
+	received := tbs.WaitForIt(1, done)
+	require.Equal(t, msg, received)
+}

--- a/server/core/nats.go
+++ b/server/core/nats.go
@@ -157,3 +157,31 @@ func (server *NATSKafkaBridge) connectToSTAN() error {
 
 	return nil
 }
+
+func (server *NATSKafkaBridge) connectToJetStream() error {
+	server.natsLock.Lock()
+	defer server.natsLock.Unlock()
+
+	if server.js != nil {
+		return nil // already connected
+	}
+
+	server.logger.Noticef("connecting to JetStream")
+
+	var opts []nats.JSOpt
+	c := server.config.JetStream
+	if c.MaxWait > 0 {
+		opts = append(opts, nats.MaxWait(time.Duration(c.MaxWait)*time.Millisecond))
+	}
+	if c.PublishAsyncMaxPending > 0 {
+		opts = append(opts, nats.PublishAsyncMaxPending(c.PublishAsyncMaxPending))
+	}
+
+	js, err := server.nats.JetStream(opts...)
+	if err != nil {
+		return err
+	}
+	server.js = js
+
+	return nil
+}


### PR DESCRIPTION
This adds JetStream support to nats-kafka. It's based off the NATS and STAN implementations.

Closes #41

### Testing

You can run the tests locally like this. (Automatically sets up and tears down Docker containers and runs Go tests.)
```
make test
```

In addition, this is how I tested manually.

```sh
# Start a Kafka server, available at localhost:9092
make setup-docker-test

# Start NATS Server with JetStream, localhost:4222
nats-server -DVV -js

# Create Stream for baz
nats stream create --subjects baz mystream1

# Create Stream for bang
nats stream create --subjects bang mystream2

# Create Consumer
nats consumer add --target mytarget mystream2 myconsumer2

# Start nats-kafka
nats-kafka -c nats-kafka.conf

# Publish on Stream
nats pub baz "hi $(date)"

# Subscribe on delivery subject
nats sub mytarget

# Shutdown Kafka
make teardown-docker-test
```

Here's the config file.
```
nats: {
  Servers: ["localhost:4222"],
}

jetstream: {
	maxwait: 5000,
}

connect: [
  {
      type: "JetStreamToKafka",
      brokers: ["localhost:9092"]
      id: "foo",
      topic: "bar",
      subject: "baz",
  },
  {
    type: "KafkaToJetStream",
    brokers: ["localhost:9092"]
    id: "whizz",
    topic: "bar",
    subject: "bang",
  },
]
```