### PR TITLE
Skip JetStream if not configured

### DIFF
--- a/server/core/nats.go
+++ b/server/core/nats.go
@@ -166,6 +166,18 @@ func (server *NATSKafkaBridge) connectToJetStream() error {
 		return nil // already connected
 	}
 
+	var hasJetStream bool
+	for _, c := range server.config.Connect {
+		if strings.Contains(c.Type, "JetStream") {
+			hasJetStream = true
+			break
+		}
+	}
+	if !hasJetStream {
+		server.logger.Noticef("skipping JetStream connection, not configured")
+		return nil
+	}
+
 	server.logger.Noticef("connecting to JetStream")
 
 	var opts []nats.JSOpt

--- a/server/core/nats2kafka_test.go
+++ b/server/core/nats2kafka_test.go
@@ -675,3 +675,21 @@ func TestNATSConnectorError(t *testing.T) {
 
 	require.NotEqual(t, n1, n2)
 }
+
+func TestBridgeStartsJetStreamDisabled(t *testing.T) {
+	connect := []conf.ConnectorConfig{
+		{
+			Type:    "NATSToKafka",
+			Subject: nuid.Next(),
+			Topic:   nuid.Next(),
+		},
+	}
+
+	tbs, err := StartTestEnvironmentInfrastructure(false, false, collectTopics(connect))
+	require.NoError(t, err)
+	defer tbs.Close()
+
+	require.NoError(t, tbs.Gnatsd.DisableJetStream())
+
+	require.NoError(t, tbs.StartBridge(connect))
+}


### PR DESCRIPTION
This skips trying to connect to JetStream if it's missing from the nats-kafka configuration.