### PR TITLE
LeastBytes partitioner implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@
 
 .vscode/*
 nats-kafka
+
+# IntelliJ and GoLand
+.idea

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.16
 
 require (
 	github.com/Shopify/sarama v1.29.1
+	github.com/orcaman/concurrent-map v0.0.0-20210501183033-44dafcb38ecc
 	github.com/armon/go-metrics v0.3.9 // indirect
 	github.com/fatih/color v1.12.0 // indirect
 	github.com/hashicorp/go-immutable-radix v1.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 github.com/DataDog/datadog-go v2.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
-github.com/Shopify/sarama v1.29.0 h1:ARid8o8oieau9XrHI55f/L3EoRAhm9px6sonbD7yuUE=
-github.com/Shopify/sarama v1.29.0/go.mod h1:2QpgD79wpdAESqNQMxNc0KYMkycd4slxGdV3TWSVqrU=
 github.com/Shopify/sarama v1.29.1 h1:wBAacXbYVLmWieEA/0X/JagDdCZ8NVFOfS6l6+2u5S0=
 github.com/Shopify/sarama v1.29.1/go.mod h1:mdtqvCSg8JOxk8PmpTNGyo6wzd4BMm4QXSfDnTXmgkE=
 github.com/Shopify/toxiproxy v2.1.4+incompatible h1:TKdv8HiTLgE5wdJuEML90aBgNWsokNbMijUGhmcoBJc=
@@ -151,6 +149,8 @@ github.com/nats-io/nuid v1.0.1 h1:5iA8DT8V7q8WK2EScv2padNa/rTESc1KdnPw4TC2paw=
 github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
 github.com/nats-io/stan.go v0.9.0 h1:TB73Y31au++0sU0VmnBy2pYkSrwH0zUFNRB9YePHqC4=
 github.com/nats-io/stan.go v0.9.0/go.mod h1:0jEuBXKauB1HHJswHM/lx05K48TJ1Yxj6VIfM4k+aB4=
+github.com/orcaman/concurrent-map v0.0.0-20210501183033-44dafcb38ecc h1:Ak86L+yDSOzKFa7WM5bf5itSOo1e3Xh8bm5YCMUXIjQ=
+github.com/orcaman/concurrent-map v0.0.0-20210501183033-44dafcb38ecc/go.mod h1:Lu3tH6HLW3feq74c2GC+jIMS/K2CFcDWnWD9XkenwhI=
 github.com/pascaldekloe/goe v0.1.0 h1:cBOtyMzM9HTpWjXfbbunk26uA6nG3a8n06Wieeh0MwY=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pierrec/lz4 v2.6.0+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
@@ -203,7 +203,6 @@ golang.org/x/crypto v0.0.0-20200323165209-0ec3e9974c59/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201112155050-0c6587e931a9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210314154223-e6e6c4f2bb5b/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
-golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a/go.mod h1:P+XmwS30IXTQdn5tA2iutPOUgjI07+tq3H3K9MVA1s8=
 golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e h1:gsTQYXdTw2Gq7RBsWvlQ91b+aEQ6bXFUngBGuR8sPpI=
 golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
@@ -219,7 +218,6 @@ golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
-golang.org/x/net v0.0.0-20210427231257-85d9c07bbe3a/go.mod h1:OJAsFXCWl8Ukc7SiCT/9KSuxbyM7479/AVlXFRxuMCk=
 golang.org/x/net v0.0.0-20210614182718-04defd469f4e h1:XpT3nA5TvE525Ne3hInMh6+GETgn27Zfm9dxsThnX2Q=
 golang.org/x/net v0.0.0-20210614182718-04defd469f4e/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/server/kafka/partitioner.go
+++ b/server/kafka/partitioner.go
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2020 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package kafka
+
+import (
+	"github.com/Shopify/sarama"
+	"github.com/orcaman/concurrent-map"
+	"unsafe"
+)
+
+// A balancer (or partitioner in Sarama terms) is in charge of spreading messages across available partitions of a topic.
+// Sarama provides a hash based partitioner which is default in the producer. This implementation distributes messages
+// based on number of bytes each partition has received.
+type leastBytesPartitioner struct {
+	byteCounters cmap.ConcurrentMap
+}
+
+// NewLeastBytesPartitioner function takes topic as an argument, but it is not used. This has been done as it
+// implements the sarama.PartitionerConstructor interface which requires it.
+func NewLeastBytesPartitioner(topic string) sarama.Partitioner {
+	lbp := new(leastBytesPartitioner)
+	lbp.byteCounters = cmap.New()
+	return lbp
+}
+
+func (lbp *leastBytesPartitioner) RequiresConsistency() bool {
+	return false
+}
+
+func (lbp *leastBytesPartitioner) Partition(message *sarama.ProducerMessage, numPartitions int32) (int32, error) {
+	// if partition count has reduced, remove the old entries
+	for i := int32(lbp.byteCounters.Count() - 1); i >= numPartitions; i-- {
+		lbp.byteCounters.Remove(packIntInString(i))
+	}
+
+	// if the size has increased, add counters for new partitions
+	for i := int32(lbp.byteCounters.Count()); i < numPartitions; i++ {
+		lbp.byteCounters.Set(packIntInString(i), uint64(0))
+	}
+
+	// find the entry in the byteCounters with min bytes
+	minIndex := findPartitionWithMinBytes(lbp.byteCounters)
+	minBytes, _ := lbp.byteCounters.Get(minIndex)
+	lbp.byteCounters.Set(minIndex, minBytes.(uint64)+uint64(message.Key.Length())+uint64(message.Value.Length()))
+
+	return unpackIntFromString(minIndex), nil
+}
+
+func findPartitionWithMinBytes(counters cmap.ConcurrentMap) string {
+	var minPartition string
+	var minBytes uint64
+
+	for entry := range counters.IterBuffered() {
+		curBytes, _ := entry.Val.(uint64)
+		if minBytes == 0 || curBytes < minBytes {
+			minBytes = curBytes
+			minPartition = entry.Key
+		}
+	}
+
+	return minPartition
+}
+
+func packIntInString(inputNum int32) string {
+	size := int(unsafe.Sizeof(inputNum))
+	buffer := make([]byte, size)
+	for i := 0; i < size; i++ {
+		buffer[i] = *(*uint8)(unsafe.Pointer(uintptr(unsafe.Pointer(&inputNum)) + uintptr(i)))
+	}
+
+	return string(buffer)
+}
+
+func unpackIntFromString(inputString string) int32 {
+	outputValue := int32(0)
+	inputBytes := []byte(inputString)
+	size := len(inputBytes)
+	for i := 0; i < size; i++ {
+		*(*uint8)(unsafe.Pointer(uintptr(unsafe.Pointer(&outputValue)) + uintptr(i))) = inputBytes[i]
+	}
+
+	return outputValue
+}

--- a/server/kafka/partitioner_test.go
+++ b/server/kafka/partitioner_test.go
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019-2021 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package kafka
+
+import (
+	"github.com/orcaman/concurrent-map"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestFindPartitionWithMinBytes(t *testing.T) {
+	testBytes := cmap.New()
+	testBytes.Set("0", uint64(1000))
+	testBytes.Set("1", uint64(200))
+	testBytes.Set("2", uint64(300))
+	testBytes.Set("3", uint64(100))
+	testBytes.Set("4", uint64(600))
+
+	minPartition := findPartitionWithMinBytes(testBytes)
+	require.Equal(t, "3", minPartition)
+}
+
+func TestPackIntInString(t *testing.T) {
+	require.Equal(t, "\u0002\u0000\u0000\u0000", packIntInString(2))
+}
+
+func TestUnpackIntFromString(t *testing.T) {
+	require.Equal(t, int32(2), unpackIntFromString("\u0002\u0000\u0000\u0000"))
+}

--- a/server/kafka/producer.go
+++ b/server/kafka/producer.go
@@ -57,6 +57,10 @@ func NewProducer(cc conf.ConnectorConfig, bc conf.NATSKafkaBridgeConfig, topic s
 	sc.Net.DialTimeout = time.Duration(bc.ConnectTimeout) * time.Millisecond
 	sc.ClientID = "nats-kafka-producer"
 
+	if cc.Balancer == conf.LeastBytes {
+		sc.Producer.Partitioner = NewLeastBytesPartitioner
+	}
+
 	if cc.SASL.User != "" {
 		sc.Net.SASL.Enable = true
 		sc.Net.SASL.Handshake = true


### PR DESCRIPTION
This PR adds an implementation of LeastBytes balancer which is compatible with the Sarama `Partitioner` interface. It routes messages based on the amount of bytes delivered to partitions. It uses key and value size in deciding the next partition. This implementation uses https://github.com/orcaman/concurrent-map to avoid global locking caused by a single mutex.