### PR TITLE
Bug fix in pbSerializer and code clean up

### DIFF
--- a/server/kafka/packer_utils.go
+++ b/server/kafka/packer_utils.go
@@ -16,47 +16,28 @@
 
 package kafka
 
-import "unsafe"
+import (
+	"bytes"
+	"encoding/binary"
+)
 
 // Utility functions to use with cmap.ConcurrentMap
-func packInt32InString(inputNum int32) string {
-	size := int(unsafe.Sizeof(inputNum))
-	buffer := make([]byte, size)
-	for i := 0; i < size; i++ {
-		buffer[i] = *(*uint8)(unsafe.Pointer(uintptr(unsafe.Pointer(&inputNum)) + uintptr(i)))
+func packInt32InString(inputNum int32) (string, error) {
+	buffer := new(bytes.Buffer)
+	err := binary.Write(buffer, binary.BigEndian, inputNum)
+	if err != nil {
+		return "", err
 	}
 
-	return string(buffer)
+	return buffer.String(), nil
 }
 
-func packIntInString(inputNum int) string {
-	size := int(unsafe.Sizeof(inputNum))
-	buffer := make([]byte, size)
-	for i := 0; i < size; i++ {
-		buffer[i] = *(*uint8)(unsafe.Pointer(uintptr(unsafe.Pointer(&inputNum)) + uintptr(i)))
+func unpackInt32FromString(inputString string) (int32, error) {
+	var outputValue int32
+	err := binary.Read(bytes.NewBufferString(inputString), binary.BigEndian, &outputValue)
+	if err != nil {
+		return 0, err
 	}
 
-	return string(buffer)
-}
-
-func unpackInt32FromString(inputString string) int32 {
-	outputValue := int32(0)
-	inputBytes := []byte(inputString)
-	size := len(inputBytes)
-	for i := 0; i < size; i++ {
-		*(*uint8)(unsafe.Pointer(uintptr(unsafe.Pointer(&outputValue)) + uintptr(i))) = inputBytes[i]
-	}
-
-	return outputValue
-}
-
-func unpackIntFromString(inputString string) int {
-	outputValue := 0
-	inputBytes := []byte(inputString)
-	size := len(inputBytes)
-	for i := 0; i < size; i++ {
-		*(*uint8)(unsafe.Pointer(uintptr(unsafe.Pointer(&outputValue)) + uintptr(i))) = inputBytes[i]
-	}
-
-	return outputValue
+	return outputValue, nil
 }

--- a/server/kafka/packer_utils_test.go
+++ b/server/kafka/packer_utils_test.go
@@ -19,21 +19,17 @@ package kafka
 import (
 	"testing"
 
-	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
 )
 
-func TestPackIntInString(t *testing.T) {
-	require.Equal(t, "\u0002\u0000\u0000\u0000", packInt32InString(2))
-}
-
-func TestUnpackIntFromString(t *testing.T) {
-	require.Equal(t, 2, unpackIntFromString("\u0002\u0000\u0000\u0000"))
-}
-
 func TestPackInt32InString(t *testing.T) {
-	require.Equal(t, "\u0002\u0000\u0000\u0000", packInt32InString(2))
+	op, err := packInt32InString(2)
+	assert.Nil(t, err)
+	assert.Equal(t, "\x00\x00\x00\x02", op)
 }
 
 func TestUnpackInt32FromString(t *testing.T) {
-	require.Equal(t, int32(2), unpackInt32FromString("\u0002\u0000\u0000\u0000"))
+	op, err := unpackInt32FromString("\x00\x00\x00\x02")
+	assert.Nil(t, err)
+	assert.Equal(t, int32(2), op)
 }

--- a/server/kafka/partitioner_test.go
+++ b/server/kafka/partitioner_test.go
@@ -32,6 +32,7 @@ func TestFindPartitionWithMinBytes(t *testing.T) {
 	testBytes.Set("4", uint64(600))
 
 	partitioner := new(leastBytesPartitioner)
-	minPartition := partitioner.findPartitionWithMinBytes(testBytes)
+	partitioner.byteCounters = testBytes
+	minPartition := partitioner.findPartitionWithMinBytes()
 	require.Equal(t, "3", minPartition)
 }

--- a/server/kafka/pb_schema_manager.go
+++ b/server/kafka/pb_schema_manager.go
@@ -50,7 +50,7 @@ func newProtobufSchemaManager() protobufSchemaManager {
 }
 
 func (protobufSchemaManager) getFileDescriptor(schema *srclient.Schema) (*desc.FileDescriptor, error) {
-	packedSchemaID := packIntInString(schema.ID())
+	packedSchemaID := strconv.Itoa(schema.ID())
 	if !schemaManager.protobufSchemaIDtoFDMappings.Has(packedSchemaID) {
 		errorReporter := func(err protoparse.ErrorWithPos) error {
 			position := err.GetPosition()
@@ -58,7 +58,7 @@ func (protobufSchemaManager) getFileDescriptor(schema *srclient.Schema) (*desc.F
 		}
 
 		nanoTs := strconv.FormatInt(time.Now().UnixNano(), 10)
-		schemaFileName := strconv.Itoa(schema.ID()) + "-" + nanoTs + ".proto"
+		schemaFileName := packedSchemaID + "-" + nanoTs + ".proto"
 		schemaFile, err := os.CreateTemp("", schemaFileName)
 		if err != nil {
 			return nil, err

--- a/server/kafka/pb_serializer.go
+++ b/server/kafka/pb_serializer.go
@@ -87,14 +87,13 @@ func (ps *protobufSerializer) buildMessageIndexes(schema *srclient.Schema, name 
 		i := int32(0)
 		for _, mType := range messageTypes {
 			if mType.GetName() == part {
-				indexArr := make([]byte, 4)
-				indexBuf := bytes.NewBuffer(indexArr)
-				err = binary.Write(indexBuf, binary.BigEndian, &i)
+				indexBuf := new(bytes.Buffer)
+				err = binary.Write(indexBuf, binary.BigEndian, i)
 				if err != nil {
 					return nil, err
 				}
 
-				indexes = append(indexes, indexArr...)
+				indexes = append(indexes, indexBuf.Bytes()...)
 				break
 			}
 			i++


### PR DESCRIPTION
This PR fixes the `buildMessageIndexes` function where the indexBuf would not get the result of the loop variable. This also improves the `packer_utils` to use big endian instead of small to provide consistency throughout the code.