### PR TITLE
Write message indexes correctly in protobuf

### DIFF
--- a/server/kafka/pb_deserializer.go
+++ b/server/kafka/pb_deserializer.go
@@ -36,9 +36,9 @@ type protobufDeserializer struct {
 }
 
 type protobufWrapper struct {
-	Schema           *srclient.Schema
-	MessageTypeIndex []int64
-	CleanPayload     []byte
+	Schema             *srclient.Schema
+	MessageTypeIndexes []int64
+	CleanPayload       []byte
 }
 
 func newDeserializer() pbDeserializer {
@@ -103,9 +103,9 @@ func (pd *protobufDeserializer) decodeProtobufStructures(schema *srclient.Schema
 	}
 
 	return &protobufWrapper{
-		Schema:           schema,
-		MessageTypeIndex: messageTypeIDs,
-		CleanPayload:     remainingPayload,
+		Schema:             schema,
+		MessageTypeIndexes: messageTypeIDs,
+		CleanPayload:       remainingPayload,
 	}, nil
 }
 
@@ -116,12 +116,12 @@ func (pd *protobufDeserializer) getMessageDescriptorFromMessage(wrapper *protobu
 	}
 
 	// Traverse through the message types until we find the right type as pointed to by message array index. This array
-	// of ints with each type indexed level by level.
+	// of varints with each type indexed level by level.
 	messageTypes := fd.GetMessageTypes()
 	messageTypesLen := int64(len(messageTypes))
 	var messageDescriptor *desc.MessageDescriptor
 
-	for _, i := range wrapper.MessageTypeIndex {
+	for _, i := range wrapper.MessageTypeIndexes {
 		if i > messageTypesLen {
 			// This should never happen
 			return nil, fmt.Errorf("failed to decode message type: message index is larger than message types array length")

--- a/server/kafka/producer_test.go
+++ b/server/kafka/producer_test.go
@@ -58,16 +58,22 @@ func TestSerializePayloadJson(t *testing.T) {
 func TestSerializePayloadProtobuf(t *testing.T) {
 	server := newMockSchemaServer(t)
 	defer server.close()
+	srClient := srclient.CreateSchemaRegistryClient(server.getServerURL())
 
 	producer := &saramaProducer{
 		schemaRegistryOn:     true,
-		schemaRegistryClient: srclient.CreateSchemaRegistryClient(server.getServerURL()),
+		schemaRegistryClient: srClient,
 		subjectName:          protobufSubjectName,
 		schemaVersion:        protobufSchemaVersion,
 		schemaType:           srclient.Protobuf,
 		pbSerializer:         newSerializer(),
 	}
+	schema, err := srClient.GetSchema(protobufSchemaID)
+	assert.Nil(t, err)
 
-	_, err := producer.serializePayload([]byte(protobufMessage))
+	message, err := producer.serializePayload([]byte(protobufMessage))
+	assert.Nil(t, err)
+
+	_, err = newDeserializer().Deserialize(schema, message[5:])
 	assert.Nil(t, err)
 }


### PR DESCRIPTION
An issue exists in the protobuf serializer where the message indexes array length and contents are not written correctly causing the deserialization to fail. This PR correctly sets the array length as well as the message indexes array contents using varints and also changes the serializer test to decode the message and check for validity.