### PR TITLE
Add Kafka SASL mechanism options (SCRAM SHA256/SHA512)

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -64,12 +64,24 @@ Kafka allow for SASL_PLAIN connection with user and password.  This also support
 For each connector section as needed:
 
 * `insecureskipverify` - (optional) allow for auto-adjustment for TLS handshake default to false (Azure EventHub requires this to be `true`)
+* `mechanism` - (optional) set the SASL mechanism to `scram-sha-256` or `scram-sha-512`, default is `plain`
+
 ```yaml
 "sasl": {
   "user": "userid",
   "password": "password"
 }
 ```
+
+With optional mechanism:
+```yaml
+"sasl": {
+  "user": "userid",
+  "password": "password",
+  "mechanism": "scram-sha-512"
+}
+```
+
 <a name="logging"></a>
 
 ### Logging

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/riferrei/srclient v0.4.0
 	github.com/santhosh-tekuri/jsonschema/v5 v5.0.0
 	github.com/stretchr/testify v1.7.0
+	github.com/xdg-go/scram v1.1.1
 )
 
 require (
@@ -48,11 +49,14 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/procfs v0.6.0 // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 // indirect
+	github.com/xdg-go/pbkdf2 v1.0.0 // indirect
+	github.com/xdg-go/stringprep v1.0.3 // indirect
 	go.etcd.io/bbolt v1.3.6 // indirect
 	golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e // indirect
 	golang.org/x/net v0.0.0-20210614182718-04defd469f4e // indirect
 	golang.org/x/sync v0.0.0-20201207232520-09787c993a3a // indirect
 	golang.org/x/sys v0.0.0-20210616094352-59db8d763f22 // indirect
+	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20210611083556-38a9dc6acbc6 // indirect
 	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 // indirect
 	google.golang.org/protobuf v1.25.1-0.20200805231151-a709e31e5d12 // indirect

--- a/go.sum
+++ b/go.sum
@@ -216,6 +216,12 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
+github.com/xdg-go/pbkdf2 v1.0.0 h1:Su7DPu48wXMwC3bs7MCNG+z4FhcyEuz5dlvchbq0B0c=
+github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=
+github.com/xdg-go/scram v1.1.1 h1:VOMT+81stJgXW3CpHyqHN3AXDYIMsx56mEFrB37Mb/E=
+github.com/xdg-go/scram v1.1.1/go.mod h1:RaEWvsqvNKKvBPvcKeFjrG2cJqOkHTiyTpzz23ni57g=
+github.com/xdg-go/stringprep v1.0.3 h1:kdwGpVNwPFtjs98xCGkHjQtGKh86rDcRZN17QEMCOIs=
+github.com/xdg-go/stringprep v1.0.3/go.mod h1:W3f5j4i+9rC0kuIEJL0ky1VpHXQU3ocBgklLGvcBnW8=
 github.com/xdg/scram v1.0.3/go.mod h1:lB8K/P019DLNhemzwFU4jHLhdvlE6uDZjXFejJXr49I=
 github.com/xdg/stringprep v1.0.3/go.mod h1:Jhud4/sHMO4oL310DaZAKk9ZaJ08SJfe+sJh0HrGL1Y=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
@@ -294,8 +300,9 @@ golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-golang.org/x/text v0.3.6 h1:aRYxNxv6iGQlyVaZmk6ZgYEDa+Jg18DxebPSrd6bg1M=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
+golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/time v0.0.0-20200416051211-89c76fbcd5d1/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20210611083556-38a9dc6acbc6 h1:Vv0JUPWTyeqUq42B2WJ1FeIDjjvGKoA2Ss+Ts0lAVbs=
 golang.org/x/time v0.0.0-20210611083556-38a9dc6acbc6/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=

--- a/server/conf/conf.go
+++ b/server/conf/conf.go
@@ -90,6 +90,7 @@ type SASL struct {
 	User               string
 	Password           string
 	InsecureSkipVerify bool
+	Mechanism          string
 }
 
 // MakeTLSConfig creates a tls.Config from a TLSConf, setting up the key pairs and certs

--- a/server/kafka/consumer.go
+++ b/server/kafka/consumer.go
@@ -83,7 +83,15 @@ func NewConsumer(cc conf.ConnectorConfig, dialTimeout time.Duration) (Consumer, 
 	if cc.SASL.User != "" {
 		sc.Net.SASL.Enable = true
 		sc.Net.SASL.Handshake = true
-		sc.Net.SASL.Mechanism = sarama.SASLTypePlaintext
+		if cc.SASL.Mechanism == "scram-sha256" || cc.SASL.Mechanism == "scram-sha-256" || cc.SASL.Mechanism == "sha256" {
+			sc.Net.SASL.SCRAMClientGeneratorFunc = func() sarama.SCRAMClient { return &XDGSCRAMClient{HashGeneratorFcn: SHA256} }
+			sc.Net.SASL.Mechanism = sarama.SASLTypeSCRAMSHA256
+		} else if cc.SASL.Mechanism == "scram-sha512" || cc.SASL.Mechanism == "scram-sha-512" || cc.SASL.Mechanism == "sha512" {
+			sc.Net.SASL.SCRAMClientGeneratorFunc = func() sarama.SCRAMClient { return &XDGSCRAMClient{HashGeneratorFcn: SHA512} }
+			sc.Net.SASL.Mechanism = sarama.SASLTypeSCRAMSHA512
+		} else {
+			sc.Net.SASL.Mechanism = sarama.SASLTypePlaintext
+		}
 		sc.Net.SASL.User = cc.SASL.User
 		sc.Net.SASL.Password = cc.SASL.Password
 	}

--- a/server/kafka/manager.go
+++ b/server/kafka/manager.go
@@ -43,7 +43,15 @@ func NewManager(cc conf.ConnectorConfig, bc conf.NATSKafkaBridgeConfig) (Manager
 	if cc.SASL.User != "" {
 		sc.Net.SASL.Enable = true
 		sc.Net.SASL.Handshake = true
-		sc.Net.SASL.Mechanism = sarama.SASLTypePlaintext
+		if cc.SASL.Mechanism == "scram-sha256" || cc.SASL.Mechanism == "scram-sha-256" || cc.SASL.Mechanism == "sha256" {
+			sc.Net.SASL.SCRAMClientGeneratorFunc = func() sarama.SCRAMClient { return &XDGSCRAMClient{HashGeneratorFcn: SHA256} }
+			sc.Net.SASL.Mechanism = sarama.SASLTypeSCRAMSHA256
+		} else if cc.SASL.Mechanism == "scram-sha512" || cc.SASL.Mechanism == "scram-sha-512" || cc.SASL.Mechanism == "sha512" {
+			sc.Net.SASL.SCRAMClientGeneratorFunc = func() sarama.SCRAMClient { return &XDGSCRAMClient{HashGeneratorFcn: SHA512} }
+			sc.Net.SASL.Mechanism = sarama.SASLTypeSCRAMSHA512
+		} else {
+			sc.Net.SASL.Mechanism = sarama.SASLTypePlaintext
+		}
 		sc.Net.SASL.User = cc.SASL.User
 		sc.Net.SASL.Password = cc.SASL.Password
 	}

--- a/server/kafka/producer.go
+++ b/server/kafka/producer.go
@@ -75,7 +75,15 @@ func NewProducer(cc conf.ConnectorConfig, bc conf.NATSKafkaBridgeConfig, topic s
 	if cc.SASL.User != "" {
 		sc.Net.SASL.Enable = true
 		sc.Net.SASL.Handshake = true
-		sc.Net.SASL.Mechanism = sarama.SASLTypePlaintext
+		if cc.SASL.Mechanism == "scram-sha256" || cc.SASL.Mechanism == "scram-sha-256" || cc.SASL.Mechanism == "sha256" {
+			sc.Net.SASL.SCRAMClientGeneratorFunc = func() sarama.SCRAMClient { return &XDGSCRAMClient{HashGeneratorFcn: SHA256} }
+			sc.Net.SASL.Mechanism = sarama.SASLTypeSCRAMSHA256
+		} else if cc.SASL.Mechanism == "scram-sha512" || cc.SASL.Mechanism == "scram-sha-512" || cc.SASL.Mechanism == "sha512" {
+			sc.Net.SASL.SCRAMClientGeneratorFunc = func() sarama.SCRAMClient { return &XDGSCRAMClient{HashGeneratorFcn: SHA512} }
+			sc.Net.SASL.Mechanism = sarama.SASLTypeSCRAMSHA512
+		} else {
+			sc.Net.SASL.Mechanism = sarama.SASLTypePlaintext
+		}
 		sc.Net.SASL.User = cc.SASL.User
 		sc.Net.SASL.Password = cc.SASL.Password
 	}

--- a/server/kafka/scram_client.go
+++ b/server/kafka/scram_client.go
@@ -1,0 +1,37 @@
+package kafka
+
+import (
+	"crypto/sha256"
+	"crypto/sha512"
+
+	"github.com/xdg-go/scram"
+)
+
+var (
+	SHA256 scram.HashGeneratorFcn = sha256.New
+	SHA512 scram.HashGeneratorFcn = sha512.New
+)
+
+type XDGSCRAMClient struct {
+	*scram.Client
+	*scram.ClientConversation
+	scram.HashGeneratorFcn
+}
+
+func (x *XDGSCRAMClient) Begin(userName, password, authzID string) (err error) {
+	x.Client, err = x.HashGeneratorFcn.NewClient(userName, password, authzID)
+	if err != nil {
+		return err
+	}
+	x.ClientConversation = x.Client.NewConversation()
+	return nil
+}
+
+func (x *XDGSCRAMClient) Step(challenge string) (response string, err error) {
+	response, err = x.ClientConversation.Step(challenge)
+	return
+}
+
+func (x *XDGSCRAMClient) Done() bool {
+	return x.ClientConversation.Done()
+}


### PR DESCRIPTION
Add optional `mechanism` configuration to set the SASL (auth) mechanism to `scram-sha-256` or `scram-sha-512` (default remains `plain`).