### PR TITLE
Did not have `go-version` for the test section

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -15,7 +15,6 @@ jobs:
       id: setup-go
       uses: actions/setup-go@v3
       with:
-        go-version-file: go.mod
         go-version: 1.19.x
     - name: Install tools
       run: make install-tools
@@ -31,7 +30,7 @@ jobs:
       id: setup-go
       uses: actions/setup-go@v3
       with:
-        go-version-file: go.mod
+        go-version: 1.19.x
     - name: Test and upload coverage
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Also removed go-version-file in "lint" section.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>