### PR TITLE
Bump GH Actions versions (Go; node12 deprecation)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,19 +8,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v1
+      uses: actions/checkout@v3
 
     - name: Setup Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.19
+        go-version: '1.19'
 
     - name: Setup QEMU
       uses: docker/setup-qemu-action@v2
 
     - name: Setup Docker Buildx
       id: buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@v2
 
     - name: Setup Docker Hub
       uses: docker/login-action@v2

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -15,7 +15,7 @@ jobs:
       id: setup-go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.19.x
+        go-version: '1.19.x'
     - name: Install tools
       run: make install-tools
     - name: Lint
@@ -30,7 +30,7 @@ jobs:
       id: setup-go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.19.x
+        go-version: '1.19.x'
     - name: Test and upload coverage
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Bump various GitHub Actions versions to move away from those using the deprecated node.js 12 runtime, and so remove the warnings.

Quote the Golang version string for defensiveness against version number parsing and YAML string vs version numbers.
