### PR TITLE
Add QueueSubscriber Option for JetstreamToKafka

### DIFF
--- a/conf/jetstream-kafka.conf
+++ b/conf/jetstream-kafka.conf
@@ -21,4 +21,13 @@ connect: [
     topic: "bar",
     subject: "bang",
   },
+  {
+    type: "JetStreamToKafka",
+    brokers: ["localhost:9092"]
+    id: "connector-1",
+    topic: "foo",
+    subject: "foo_subject.*",
+    durablename: "durable_foo_consumer",
+    queuename: "foo_consumers"
+  }
 ]

--- a/docs/config.md
+++ b/docs/config.md
@@ -241,7 +241,15 @@ All connectors can have an optional id, which is used in monitoring:
 For NATS connections, specify:
 
 * `subject` - for NATS/JetStream the subject to subscribe/publish to, depending on the connections direction.
-* `queuename` - the queue group to use in subscriptions, this is optional but useful for load balancing.
+* `queuename` - (optional) the queue group to use in subscriptions, this is optional but useful for load balancing.
+
+For JetStream connections, specify:
+
+* `subject` - for NATS/JetStream the subject to subscribe/publish to, depending on the connections direction.
+* `queuename` - (optional) the queue group to use in subscriptions, this is optional but useful for load balancing.
+* `durablename` - (optional) durable name for the NATS Streaming/JetStream subscription (if appropriate.)
+* `startatsequence` - (optional) for NATS Streaming/JetStream start position, use -1 for start with last received, 0 for deliver all available (the default.)
+* `startattime` - (optional) for NATS Streaming/JetStream the start position as a time, in Unix seconds since the epoch, mutually exclusive with `startatsequence`.
 
 Keep in mind that NATS queue groups do not guarantee ordering, since the queue subscribers can be on different nats-servers in a cluster. So if you have to bridges running with connectors on the same NATS queue/subject pair and have a high message rate you may get messages in the Kafka topic out of order.
 

--- a/server/core/connector.go
+++ b/server/core/connector.go
@@ -354,7 +354,7 @@ func (conn *BridgeConnector) subscribeToChannel() (stan.Subscription, error) {
 }
 
 // set up a JetStream subscription, assumes the lock is held
-func (conn *BridgeConnector) subscribeToJetStream(subject string) (*nats.Subscription, error) {
+func (conn *BridgeConnector) subscribeToJetStream(subject string, queueName string) (*nats.Subscription, error) {
 	if conn.bridge.JetStream() == nil {
 		return nil, fmt.Errorf("bridge not configured to use JetStream")
 	}
@@ -420,7 +420,11 @@ func (conn *BridgeConnector) subscribeToJetStream(subject string) (*nats.Subscri
 		}
 	}
 
-	return conn.bridge.JetStream().Subscribe(subject, callback, options...)
+	if queueName == "" {
+		return conn.bridge.JetStream().Subscribe(subject, callback, options...)
+	}
+
+	return conn.bridge.JetStream().QueueSubscribe(subject, queueName, callback, options...)
 }
 
 func (conn *BridgeConnector) setUpListener(target kafka.Consumer, natsCallbackFunc NATSCallback) (ShutdownCallback, error) {

--- a/server/core/jetstream2kafka.go
+++ b/server/core/jetstream2kafka.go
@@ -47,7 +47,7 @@ func (conn *JetStream2KafkaConnector) Start() error {
 
 	conn.bridge.Logger().Tracef("starting connection %s", conn.String())
 
-	sub, err := conn.subscribeToJetStream(conn.config.Subject)
+	sub, err := conn.subscribeToJetStream(conn.config.Subject, conn.config.QueueName)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR adds a feature that provides connecting a jetstream with multiple push subscribers with a queue group in order to provide horizontal scalability and fault tolerance support.

This may be a solution to the issue #88 