### PR TITLE
Support bind stream JS option

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -16,7 +16,7 @@ variable CI {
 }
 
 variable image_base {
-  default = "docker-image://alpine:3.17.3"
+  default = "docker-image://alpine:3.18.4"
 }
 
 variable image_goreleaser {

--- a/server/conf/conf.go
+++ b/server/conf/conf.go
@@ -209,6 +209,7 @@ type ConnectorConfig struct {
 
 	Subject   string // Used for nats and jetstream connections
 	QueueName string // Optional, used for nats connections
+	Stream    string // Uses BindStream option for JetStream to consume from sourced streams
 
 	Brokers []string // list of brokers to use for creating a reader/writer
 	Topic   string   // kafka topic

--- a/server/core/connector.go
+++ b/server/core/connector.go
@@ -382,6 +382,9 @@ func (conn *BridgeConnector) subscribeToJetStream(subject string) (*nats.Subscri
 	if d := conn.bridge.config.JetStream.HeartbeatInterval; d > 0 {
 		options = append(options, nats.IdleHeartbeat(time.Duration(d)*time.Millisecond))
 	}
+	if len(conn.config.Stream) > 0 {
+		options = append(options, nats.BindStream(conn.config.Stream))
+	}
 
 	traceEnabled := conn.bridge.Logger().TraceEnabled()
 	ackSyncEnabled := conn.bridge.config.JetStream.EnableAckSync

--- a/server/core/jetstream2kafka.go
+++ b/server/core/jetstream2kafka.go
@@ -81,7 +81,7 @@ func (conn *JetStream2KafkaConnector) Shutdown() error {
 // CheckConnections ensures the nats/stan connection and report an error if it is down
 func (conn *JetStream2KafkaConnector) CheckConnections() error {
 	if !conn.bridge.CheckJetStream() {
-		return fmt.Errorf("%s connector requires nats streaming to be available", conn.String())
+		return fmt.Errorf("%s connector requires nats jetstream to be available", conn.String())
 	}
 	return nil
 }

--- a/server/core/kafka2jetstream.go
+++ b/server/core/kafka2jetstream.go
@@ -103,7 +103,7 @@ func (conn *Kafka2JetStreamConnector) Shutdown() error {
 // CheckConnections ensures the nats/stan connection and report an error if it is down
 func (conn *Kafka2JetStreamConnector) CheckConnections() error {
 	if !conn.bridge.CheckJetStream() {
-		return fmt.Errorf("%s connector requires nats streaming to be available", conn.String())
+		return fmt.Errorf("%s connector requires nats jetstream to be available", conn.String())
 	}
 	return nil
 }


### PR DESCRIPTION
add support to consume from streams that use sources:

```hcl
connect: [
  {
      type: "JetStreamToKafka",
      brokers: ["127.0.0.1:9092"]
      id: "Telemetry",
      topic: "nats.telemetry",
      subject: "foo.*",
      durablename: "KafkaBridgeConsumer",
      stream: foo_global # Stream that is composed of many streams.
  },
],
```