### PR TITLE
Add SASL TLS option to always use tls

### DIFF
--- a/server/conf/conf.go
+++ b/server/conf/conf.go
@@ -85,12 +85,13 @@ type TLSConf struct {
 	Root string
 }
 
-// SASL holds the configuration for SASL authentication.
+// SASL holds the configuration for SASL authentication with Kafka.
 type SASL struct {
 	User               string
 	Password           string
 	InsecureSkipVerify bool
 	Mechanism          string
+	TLS                bool
 }
 
 // MakeTLSConfig creates a tls.Config from a TLSConf, setting up the key pairs and certs

--- a/server/kafka/producer.go
+++ b/server/kafka/producer.go
@@ -96,6 +96,9 @@ func NewProducer(cc conf.ConnectorConfig, bc conf.NATSKafkaBridgeConfig, topic s
 		sc.Net.TLS.Enable = true
 		sc.Net.TLS.Config = tlsC
 	}
+	if cc.SASL.TLS {
+		sc.Net.TLS.Enable = cc.SASL.TLS
+	}
 
 	sp, err := sarama.NewSyncProducer(cc.Brokers, sc)
 	if err != nil {


### PR DESCRIPTION
Adds a `tls` option to the SASL block to opt into using TLS always:

```hcl
connect: [
  {
      type: "JetStreamToKafka",
      brokers: ["<my-brokers>:9096","<my-brokers>:9096"]
      id: "Telemetry",
      topic: "foo",
      subject: "foo",
      durablename: "KafkaBridgeConsumer2",
      stream: foo
      sasl: {
        "user": "admin",
        "password": "secret",
        "mechanism": "scram-sha-512",
        "tls": true
      }
  },
],
```