### PR TITLE
add template function to use kafka header value by key

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -301,4 +301,4 @@ If unset, an empty key is assigned during translation from NATS to Kafka. If the
 
 For NATS Streaming connections channel is treated as the subject and durable name is treated as the reply to, so that reply key type will use the durable name as the key.
 
-Every destination, may it be channel, subject or topic may be set using a go template that gets the message as data. e.g `topic: "{{ .Subject }}"`. Two template functions are available: replace (`"{{ .Subject | replace \"event\" \"message\" }}`) and substring (`"{{ .Subject | substring 0 5 }}"`)
+Every destination, may it be channel, subject or topic may be set using a go template that gets the message as data. e.g `topic: "{{ .Subject }}"`. Three template functions are available: replace (`"{{ .Subject | replace \"event\" \"message\" }}`), substring (`"{{ .Subject | substring 0 5 }}"`) and getKafkaHeaderValue(`"{{ .Headers | getKafkaHeaderValue \"baz\"}}"`)

--- a/server/core/connector.go
+++ b/server/core/connector.go
@@ -550,6 +550,14 @@ func (conn *BridgeConnector) initDestTemplate(destTpl string) {
 			}
 			return s[start:end]
 		},
+		"getKafkaHeaderValue": func(key string, headers []sarama.RecordHeader) string {
+		   for _, header := range(headers) {
+			   if string(header.Key) == key {
+				   return string(header.Value)
+			   }
+		   }
+		   return ""
+	   },
 	}
 	var err error
 	conn.destTemplate, err = template.New("dest").Funcs(funcMap).Parse(destTpl)


### PR DESCRIPTION
### What motivated this proposal?

The current nats-kafka-bridge is missing the capability to demux messages from kafka to nats based on the kafka messages' header values. With this change, we can use nats-kafka-bridge as a demuxer by further specifying the patterns or criterions in the kafka message header. 

### What is the proposed change?

In `server/core/connector.go:553` add:
```
		"getKafkaHeaderValue": func(key string, headers []sarama.RecordHeader)
		 string {
			for _, header := range(headers) {
				if string(header.Key) == key {
					return string(header.Value)
				}
			}
			return ""
		},
```

### Who benefits from this change?

Anyone who is using nats-kafka-bridge as a kafka message demuxer to many nats subjects with similar patterns.

### Example
```
connect: [
  {
      type: "KafkaToNATS",
      brokers: ["localhost:9092"]
      id: "foo",
      topic: "bar",
      subject: "Subject-{{ .Headers | getKafkaHeaderValue \"baz\"}}",
  },
]
```
