### PR TITLE
Propagating nats-time to Kafka Message Headers

### DIFF
--- a/server/core/connector.go
+++ b/server/core/connector.go
@@ -262,12 +262,21 @@ func (conn *BridgeConnector) subscribeToNATS(subject string, queueName string) (
 	callback := func(msg *nats.Msg) {
 		start := time.Now()
 		l := int64(len(msg.Data))
+		headers := conn.convertFromNatsToKafkaHeaders(msg.Header)
+
+		// append nats-time header if available
+		if md, mdErr := msg.Metadata(); mdErr == nil && md != nil {
+			headers = append(headers, sarama.RecordHeader{
+				Key:   []byte("nats-time"),
+				Value: []byte(md.Timestamp.Format(time.RFC3339Nano)),
+			})
+		}
 
 		// send to kafka here
 		err := conn.writer(msg).Write(kafka.Message{
 			Key:     conn.calculateKey(msg.Subject, msg.Reply),
 			Value:   msg.Data,
-			Headers: conn.convertFromNatsToKafkaHeaders(msg.Header),
+			Headers: headers,
 		})
 
 		if err != nil {
@@ -398,10 +407,20 @@ func (conn *BridgeConnector) subscribeToJetStream(subject string, queueName stri
 		}
 
 		key := conn.calculateKey(conn.config.Subject, conn.config.DurableName)
+		headers := conn.convertFromNatsToKafkaHeaders(msg.Header)
+
+		//append nats-time header if available
+		if md, mdErr := msg.Metadata(); mdErr == nil && md != nil {
+			headers = append(headers, sarama.RecordHeader{
+				Key:   []byte("nats-time"),
+				Value: []byte(md.Timestamp.Format(time.RFC3339Nano)),
+			})
+		}
+
 		err := conn.writer(msg).Write(kafka.Message{
 			Key:     key,
 			Value:   msg.Data,
-			Headers: conn.convertFromNatsToKafkaHeaders(msg.Header),
+			Headers: headers,
 		})
 
 		if err != nil {


### PR DESCRIPTION
## Problem
When nats-kafka bridges messages from NATS (or JetStream) to Kafka, the original publish timestamp recorded by the NATS server is lost. Kafka assigns its own broker-side timestamp on arrival, but that reflects when the message reached the Kafka cluster -- not when it was originally published to NATS. For any system that needs to reason about the true origin time of a message, this gap is a blind spot.

## What Changed
The bridge now reads the Timestamp field from JetStream message metadata (msg.Metadata().Timestamp) and forwards it as a nats-time Kafka record header, formatted as RFC 3339 with nanosecond precision. The header is appended alongside any existing NATS headers that are already converted. When metadata is unavailable (e.g. plain NATS core subscriptions), the header is omitted.

## Why It Matters
End-to-end latency measurement. Kafka consumers can compare nats-time against the Kafka broker timestamp or their own wall-clock receive time to compute the true end-to-end propagation delay across the bridge. Without the origin timestamp, latency dashboards can only measure from the Kafka side.

Correct event ordering and windowing. Stream-processing frameworks (Kafka Streams, Flink, ksqlDB) let you key time windows on a custom timestamp. Using nats-time as the event-time allows windows and watermarks to reflect when the event actually occurred in the source system, not when it transited through the bridge. This is critical for out-of-order or delayed messages.

Decoupling from bridge throughput. Bridge throughput fluctuations, back-pressure, and restarts can introduce variable delays between NATS publish time and Kafka ingest time. Relying solely on the Kafka timestamp means that downstream analytics silently absorb those delays as if they were part of the event timeline. Propagating the origin timestamp isolates the producer's timeline from the bridge's operational characteristics.
